### PR TITLE
[PTNFLY-2802] add initial js for vertical nav demo

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -53,7 +53,7 @@ body {
 
 .pf-vertical-sub-nav {
   display: none; }
-  .pf-vertical-sub-nav.pf-is-open {
+  .pf-vertical-sub-nav:not([aria-hidden="true"]) {
     display: block; }
 
 @media (min-width: 50rem) {

--- a/js/navbar.js
+++ b/js/navbar.js
@@ -1,0 +1,145 @@
+(function ($) {
+  'use strict';
+
+  let menuItemDepth = function ($menuItem) {
+    return $menuItem.parents('li').length;
+  },
+
+  hasSubmenu = function ($menuItem) {
+    // if the menu item has a sub-menu, it will have a value for [aria-controls]
+    return !!$menuItem.attr('aria-controls');
+  },
+
+  subMenuIsVisible = function ($subMenu) {
+    return !!$subMenu.is(':visible');
+  },
+
+  openMenu = function ($menuItem, $subMenu) {
+    $menuItem.attr('aria-expanded', true);
+    $subMenu.attr('aria-hidden', false);
+  },
+
+  closeMenu = function ($menuItem, $subMenu) {
+    $menuItem.attr('aria-expanded', false);
+    $subMenu.attr('aria-hidden', true);
+  },
+
+  getMenuItemLnk = function (item) {
+    return $(item).find('> a');
+  },
+
+  focusFirstMenuItem = function ($subMenu) {
+    $subMenu.find('ul li:first a').trigger('focus');
+  },
+
+  getSubMenu = function ($menuItem) {
+    let subMenuSelector = '#' + $menuItem.attr('aria-controls');
+    return $(subMenuSelector);
+  },
+
+  closeOpenMenus = function ($menuItems) {
+    $.each($menuItems, function (idx, item) {
+      if (getMenuItemLnk(item).attr('aria-expanded') === 'true') {
+        let $subMenu = getSubMenu(getMenuItemLnk(item));
+        closeMenu(getMenuItemLnk(item), $subMenu);
+      }
+    });
+  },
+
+  removeActiveClasses = function ($menuItems) {
+    $.each($menuItems, function (idx, item) {
+      if (getMenuItemLnk(item).is('.pf-is-active')) {
+        getMenuItemLnk(item).removeClass('pf-is-active');
+      }
+    });
+  },
+
+  removeAriaCurrent = function ($menuItems) {
+    $.each($menuItems, function (idx, item) {
+      if (getMenuItemLnk(item).attr('aria-current') === 'true') {
+        getMenuItemLnk(item).attr('aria-current', false);
+      }
+    });
+  },
+
+  removeCurrentNavItemText = function ($menuItems) {
+    $.each($menuItems, function (idx, item) {
+      let $item = getMenuItemLnk(item);
+      if ($item.is(':not([aria-disabled])') && $item.find('.sr-only').length > 0) {
+        getMenuItemLnk(item).find('.sr-only').remove();
+      }
+    });
+  },
+
+  bindMenuEvents = function ($listItem, idx, $menuItems) {
+    let $menuItem = $listItem.find('> a');
+
+    $menuItem.on('focus click focusout focusin', function (event) {
+      event.preventDefault();
+
+      let $subMenu = getSubMenu($menuItem);
+
+      switch (event.type) {
+
+        case 'focusin': {
+
+          $menuItem.on('click', function (event) {
+            event.preventDefault();
+            event.stopImmediatePropagation();
+
+            if (hasSubmenu($menuItem)) {
+              if ($subMenu.attr('aria-hidden') === 'true') {
+
+                // first close any subMenus that are already open
+                closeOpenMenus($menuItems);
+
+                openMenu($menuItem, $subMenu);
+                focusFirstMenuItem($subMenu);
+              } else {
+                closeMenu($menuItem, $subMenu);
+              }
+            }
+
+            // only set as pf-is-active/aria-current if menu item isn't disabled and isn't only a gateway to submenu
+            if (!hasSubmenu($menuItem) && $menuItem.is(':not([aria-disabled])')) {
+              removeActiveClasses($menuItems);
+              removeAriaCurrent($menuItems);
+              removeCurrentNavItemText($menuItems);
+              $menuItem.addClass('pf-is-active').attr('aria-current', true);
+
+              $menuItem.find('.pf-c-vertical-nav__link-text').append('<span class="sr-only">(current navigation item)</span>');
+              let menuItemText = $menuItem.find('.pf-c-vertical-nav__link-text').text().trim();
+
+              if (menuItemDepth($menuItem) === 1) {
+                closeOpenMenus($menuItems);
+              }
+            }
+
+          });
+
+          break;
+        }
+
+        case 'focusout': {
+          $menuItem.off('click');
+          break;
+        }
+
+        default: {
+          // console.log('unsupported event type');
+        }
+      }
+      return false;
+    });
+  };
+
+  document.addEventListener("DOMContentLoaded", function(event) {
+    let $menuItems = $('.pf-c-vertical-nav__item, .pf-vertical-sub-nav__item');
+
+    $.each($menuItems, function (idx, element) {
+      let $listItem = $(element);
+      bindMenuEvents($listItem, idx, $menuItems);
+    });
+  });
+
+})(jQuery);

--- a/navbar.html
+++ b/navbar.html
@@ -9,15 +9,11 @@
 </head>
 <body>
 
-  <nav class="pf-c-vertical-nav" role="navigation">
-  <!-- Do we still need role="navigation" for <nav> elements -->
-
+  <nav class="pf-c-vertical-nav">
     <ul class="pf-c-vertical-nav__content" role="list">
-
-      <li class="pf-c-vertical-nav__item" role="listitem">
+      <li class="pf-c-vertical-nav__item">
 
         <!-- JS NOTES for any <a> menu item that DOES NOT have a submenu-->
-
         <!-- aria-current= -->
         <!-- "true" when this menu item is the current page (i.e. active) -->
         <!-- "false" when any other menu item is the current page -->
@@ -28,14 +24,14 @@
         </a>
       </li>
 
-      <li class="pf-c-vertical-nav__item" role="listitem">
+      <li class="pf-c-vertical-nav__item">
         <a href="#" class="pf-c-vertical-nav__link">
           <span class="pf-c-vertical-nav__link-icon"><i class="fas fa-home"></i></span>
-          <span class="pf-c-vertical-nav__link-text">Item</span>
+          <span class="pf-c-vertical-nav__link-text">Item One</span>
         </a>
       </li>
 
-      <li class="pf-c-vertical-nav__item" role="listitem">
+      <li class="pf-c-vertical-nav__item">
 
         <!-- JS NOTES for any <a> menu item that DOES have a submenu-->
 
@@ -46,40 +42,57 @@
         <!-- aria-current="false" when any other menu item is the current page -->
         <!-- except, this doesn't work in Voiceover on Mac - instead only the first aria-current attribute is recognized. Is it too much to transfer this attribute dynamically depending on menu visibility? so when the menu is hidden, the parent has ariaa-current and when the menu is visible the submenu item has aria-current -->
 
-        <a href="#" aria-expanded="true" aria-controls="navbarSubmenu3" aria-current="true" class="pf-c-vertical-nav__link pf-is-active" id="navbarDropdownMenuLink3"> <!-- pf-is-active class is added to links that are open -->
+        <a
+          href="#"
+          aria-expanded="false"
+          aria-controls="navbarSubmenu3"
+          aria-current="false"
+          class="pf-c-vertical-nav__link"
+          id="navbarDropdownMenuLink3"> <!-- pf-is-active class is added to links that are open -->
           <span class="pf-c-vertical-nav__link-icon">
             <i class="fas fa-home"></i>
           </span>
           <span class="pf-c-vertical-nav__link-text">
-            <!-- JS NOTES for any <a> element that also has aria-current, as noted above-->
-            <!-- include the following element after the menu item text string, whenever the menu item is the current page, or is a parent of the current page -->
-            <!-- <span class="sr-only">(current navigation item)</span> -->
-            Item Active <span class="sr-only">(current navigation item)</span>
+            Item Two
           </span>
         </a>
 
         <!-- JS NOTES for submenus -->
         <!-- aria-hidden="true" when the submenu is not visible -->
         <!-- aria-hidden="false" (or not included) when the submenu is visible -->
-        <section class="pf-vertical-sub-nav pf-is-open" aria-labelledby="navbarDropdownMenuLink3" id="navbarSubmenu3" aria-hidden="false"> <!-- pf-is-open class is added to sections that are open -->
+        <section
+          class="pf-vertical-sub-nav"
+          aria-hidden="true"
+          aria-labelledby="navbarDropdownMenuLink3"
+          id="navbarSubmenu3"> <!-- pf-is-open class is added to sections that are open -->
           <h2 class="pf-vertical-sub-nav__title">Submenu title</h2>
-          <ul class="pf-vertical-sub-nav__content" role="list">
-            <li class="pf-vertical-sub-nav__item" role="listitem">
-              <a href="#" class="pf-vertical-sub-nav__link">SubItem One</a>
+          <ul class="pf-vertical-sub-nav__content">
+            <li class="pf-vertical-sub-nav__item">
+              <a href="#" class="pf-vertical-sub-nav__link">
+                <span class="pf-c-vertical-nav__link-text">
+                    SubItem One
+                </span>
+              </a>
             </li>
-            <li class="pf-vertical-sub-nav__item" role="listitem">
+            <li class="pf-vertical-sub-nav__item">
 
               <!-- JS NOTES for any <a> menu item that IS IN a submenu-->
               <!-- aria-current="true" when this menu item is the current page (i.e. active) -->
               <!-- aria-current="false" when any other menu item is the current page -->
-              <a href="#" aria-current="true" class="pf-vertical-sub-nav__link pf-is-active">
-                SubItem Two <span class="sr-only">(current navigation item)</span>
+              <a href="#" aria-current="false" class="pf-vertical-sub-nav__link">
+                <span class="pf-c-vertical-nav__link-text">
+                  SubItem Two
+                </span>
               </a>
             </li>
-            <li class="pf-vertical-sub-nav__item" role="listitem">
-              <a href="#" class="pf-vertical-sub-nav__link">SubItem Three</a>
+            <li class="pf-vertical-sub-nav__item">
+              <a href="#" class="pf-vertical-sub-nav__link">
+                <span class="pf-c-vertical-nav__link-text">
+                  SubItem Three
+                </span>
+              </a>
             </li>
-            <li class="pf-vertical-sub-nav__item" role="listitem">
+            <li class="pf-vertical-sub-nav__item">
               <a href="#" aria-disabled="true" class="pf-vertical-sub-nav__link pf-is-disabled">SubItem Disabled <span class="sr-only">(disabled navigation item)</span></a>
             </li>
           </ul>
@@ -87,27 +100,44 @@
       </li>
 
       <li class="pf-c-vertical-nav__item">
-        <a href="#" aria-expanded="false" aria-controls="navbarSubmenu4" class="pf-c-vertical-nav__link" id="navbarDropdownMenuLink4">
+        <a
+          href="#"
+          aria-expanded="false"
+          aria-controls="navbarSubmenu4"
+          class="pf-c-vertical-nav__link"
+          id="navbarDropdownMenuLink4">
           <span class="pf-c-vertical-nav__link-icon">
             <i class="fas fa-home"></i>
           </span>
-          <span class="pf-c-vertical-nav__link-text">Item</span>
+          <span class="pf-c-vertical-nav__link-text">Item Three</span>
         </a>
 
-        <!-- HTML NOTES -->
-        <!-- The following menu has a variation, where aria-level is used to identify list level -->
-        <!-- Aside from the additional aria attribute, the JS updates should be the same for this section -->
-        <section class="pf-vertical-sub-nav" aria-labelledby="navbarDropdownMenuLink4" id="navbarSubmenu4" aria-hidden="false">
+        <!-- HTML NOTES
+        The following menu has a variation, where aria-level is used to identify list level
+        Aside from the additional aria attribute, the JS updates should be the same for this section -->
+        <section class="pf-vertical-sub-nav" aria-labelledby="navbarDropdownMenuLink4" id="navbarSubmenu4" aria-hidden="true">
           <h2 class="pf-vertical-sub-nav__title">Submenu title</h2>
           <ul class="pf-vertical-sub-nav__content">
             <li class="pf-vertical-sub-nav__item" aria-level="2">
-              <a href="#" class="pf-vertical-sub-nav__link">SubItem One</a>
+              <a href="#" class="pf-vertical-sub-nav__link">
+                <span class="pf-c-vertical-nav__link-text">
+                  SubItem One
+                </span>
+              </a>
             </li>
             <li class="pf-vertical-sub-nav__item" aria-level="2">
-              <a href="#" class="pf-vertical-sub-nav__link pf-is-active">SubItem Two</a>
+              <a href="#" class="pf-vertical-sub-nav__link">
+                <span class="pf-c-vertical-nav__link-text">
+                  SubItem Two
+                </span>
+              </a>
             </li>
             <li class="pf-vertical-sub-nav__item" aria-level="2">
-              <a href="#" class="pf-vertical-sub-nav__link">SubItem Three</a>
+              <a href="#" class="pf-vertical-sub-nav__link">
+                <span class="pf-c-vertical-nav__link-text">
+                  SubItem Three
+                </span>
+              </a>
             </li>
             <li class="pf-vertical-sub-nav__item" aria-level="2">
               <a href="#" aria-disabled="true" class="pf-vertical-sub-nav__link pf-is-disabled">SubItem Disabled <span class="sr-only">(disabled navigation item)</span></a>
@@ -135,6 +165,7 @@
 
     </ul>
   </nav>
-
+  <script src="https://code.jquery.com/jquery-3.3.1.js" integrity="sha256-2Kok7MbOyxpgUVvAk/HJ2jigOSYS2auK4Pfzbm7uH60=" crossorigin="anonymous"></script>
+  <script src="js/navbar.js"></script>
 </body>
 </html>

--- a/sass/base.scss
+++ b/sass/base.scss
@@ -49,7 +49,7 @@ body {
     &:hover,
     &:focus {
       background-color: rgba(0, 0, 0, 0.05); //$pf-vertical-sub-nav-link-hover-bg-color;
-   
+
     }
 
     &-icon {
@@ -80,7 +80,11 @@ body {
 .pf-vertical-sub-nav {
   display: none;
 
-  &.pf-is-open {
+  // &.pf-is-open {
+  //   display: block;
+  // }
+  // rather, base display on aria-hidden
+  &:not([aria-hidden="true"]) {
     display: block;
   }
 }
@@ -119,7 +123,7 @@ body {
   &:hover,
   &:focus {
     background-color: rgba(0, 0, 0, 0.05); //$pf-vertical-sub-nav-link-hover-bg-color;
- 
+
   }
 
   &.pf-is-disabled {
@@ -183,7 +187,7 @@ body {
 // btn
 .pf-c-btn {
   padding: 0rem 1rem;
-  background-color: white; 
+  background-color: white;
 }
 
 // drop menu
@@ -212,11 +216,11 @@ body {
   &.pf-is-expanded .pf-c-dropdown__menu {
     display: block;
   }
-  
+
   &.pf-to-right .pf-c-dropdown__menu {
     right: 0;
     left: auto;
   }
-  
+
 
 }


### PR DESCRIPTION
This PR adds interactivity to the vertical navigation demo. Sets aria-expanded, aria-current, sr-only text, and active state classes based on events triggered when using a keyboard to drive the menu.

A stepping stone toward more comprehensive accessibility support.

Base submenu display on aria-hidden instead of pf-is-open
Add missing nested spans to anchors in sub menu
Remove listitem role from list items as it causes menu items to be read twice in VO
Unset aria-* in initial markup so it can be driven predictably with js
Remove redundant navigation role from nav element
Add basic js to driving sub menus, aria attrs, and setting classes dynamically