### PR TITLE
Nav toast notification

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -15,6 +15,9 @@ body {
   background-color: transparent;
   text-rendering: optimizeLegibility; }
 
+.nav-list-example [aria-hidden="true"] {
+  display: none; }
+
 @media (min-width: 50rem) {
   .pf-c-vertical-nav {
     width: 15rem; } }

--- a/index.html
+++ b/index.html
@@ -8,8 +8,9 @@
   <body>
 
     <ul>
-      <li><a href="navbar-list.html">Navbar (role list)</a></li>
-      <li><a href="navbar-menubar.html">Navbar (role menubar)</a></li>
+      <li><a href="single-notification.html">Single Notification Container</a></li>
+      <li><a href="navbar-list.html">Navbar as a list</a></li>
+      <li><a href="navbar-menubar.html">Navbar as a menu</a></li>
       <li><a href="navbar-aria.html">Navbar ARIA</a></li>
       <li><a href="toast.html">Toast</a></li>
       <li><a href="kebab.html">Kebab</a></li>

--- a/js/navbar-menubar.js
+++ b/js/navbar-menubar.js
@@ -62,15 +62,6 @@
     });
   },
 
-  assignHasPopupAttrs = function ($listItem) {
-    let $menuItem = $listItem.find('> a');
-
-    if (hasSubmenu($menuItem)) {
-      console.log('menu item has subMenu', $menuItem);
-      $menuItem.attr('aria-haspopup', 'menuitem');
-    }
-  },
-
   bindMenuEvents = function ($listItem, idx, $menuItems) {
     let $menuItem = $listItem.find('> a');
 
@@ -135,7 +126,7 @@
     $.each($menuItems, function (idx, element) {
       let $listItem = $(element);
       bindMenuEvents($listItem, idx, $menuItems);
-      // assignHasPopupAttrs($listItem);
+      getMenuItemLnk(element).attr('role', 'menuitem');
     });
   });
 

--- a/js/single-notification.js
+++ b/js/single-notification.js
@@ -109,17 +109,61 @@
               removeAriaCurrent($menuItems);
               $menuItem.addClass('pf-is-active').attr('aria-current', true);
 
-              let menuItemTxt = $menuItem.find('[class*="link-text"]').text().trim();
+              let menuItemTxt = $menuItem.find('[class*="link-text"]').text().trim(),
+                $notifEl = $('#notification-element'),
+                $screenReaderNotifTitle = $notifEl.find('#notification-element-title'),
+                $screenReaderNotifMsg = $notifEl.find('#notification-element-message');
 
               switch (menuItemTxt) {
-                case 'Technology': {
-                  popNotification($('#technology-warning'));
-                  focusFirstMenuItem($('#technology-warning'));
+                case 'Alert': {
+                  // update attrs
+                  $notifEl.attr('role', 'alert');
+                  // $notifEl.attr('aria-live', 'assertive');
+
+                  // update classes
+                  $notifEl.removeClass('pf-is-success').addClass('pf-is-warning');
+
+                  // update text
+                  $screenReaderNotifTitle.html('ALERT:');
+                  $screenReaderNotifMsg.html('This is an important alert message.');
+                  $notifEl.find('.pf-c-toast__action').attr('aria-hidden', true);
+
+                  // launch notification
+                  popNotification($notifEl);
+                  focusFirstMenuItem($notifEl);
                   break;
                 }
-                case 'Entertainment': {
-                  popNotification($('#entertainment-info'));
-                  // focusFirstMenuItem($('#entertainment-info')); // don't do this for role="status"!!
+                case 'Alert Dialog': {
+                  // update attrs
+                  $notifEl.attr('role', 'alertdialog');
+                  $notifEl.attr('aria-live', 'assertive');
+
+                  // update classes
+                  $notifEl.removeClass('pf-is-success').addClass('pf-is-warning');
+
+                  // update text
+                  $screenReaderNotifTitle.html('ALERT DIALOG:');
+                  $screenReaderNotifMsg.html('This is an alert dialog.');
+                  $notifEl.find('.pf-c-toast__action').removeAttr('aria-hidden');
+
+                  // launch notification
+                  popNotification($notifEl);
+                  focusFirstMenuItem($notifEl);
+                  break;
+                }
+                case 'Status': {
+                  // update attrs
+                  $notifEl.attr('role', 'status');
+                  $notifEl.attr('aria-live', 'polite');
+
+                  // update classes
+                  $notifEl.removeClass('pf-is-warning ').addClass('pf-is-success');
+
+                  // update text
+                  $screenReaderNotifTitle.html('STATUS:');
+                  $screenReaderNotifMsg.html('This is a relaxed status update.');
+                  $notifEl.find('.pf-c-toast__action').attr('aria-hidden', true);
+                  popNotification($notifEl);
                   break;
                 }
                 default: {}

--- a/navbar-list.html
+++ b/navbar-list.html
@@ -2,15 +2,15 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Navigation Example - aria-expanded</title>
+  <title>Navigation Example</title>
   <link rel="stylesheet" href="node_modules/normalize.css/normalize.css">
   <link rel="stylesheet" href="css/base.css">
   <script defer src="https://use.fontawesome.com/releases/v5.0.6/js/all.js"></script>
 </head>
-<body>
+<body class="nav-list-example">
 
   <header role="banner">
-    <h1>List demo</h1>
+    <h1>Navigation list launching submenus and notifications demo</h1>
   </header>
 
   <nav class="pf-c-vertical-nav">
@@ -48,7 +48,6 @@
 
         <a
           href="#"
-          role="link"
           aria-expanded="false"
           aria-controls="navbarSubmenu3"
           aria-current="false"
@@ -107,7 +106,6 @@
       <li class="pf-c-vertical-nav__item">
         <a
           href="#"
-          role="link"
           aria-expanded="false"
           aria-controls="navbarSubmenu4"
           class="pf-c-vertical-nav__link"
@@ -173,12 +171,67 @@
   </nav>
   <main>
     <ul>
-      <li>features role="list" for outermost ul</li>
-      <li>features dynamic aria-expanded on each menu anchor</li>
-      <li>features dynamic aria-current on each menu anchor</li>
-      <li>does not properly relay expanded/collapsed state in VoiceOver links menu</li>
-      <li>submenu links are however listed properly in VO links menu when they are expanded</li>
+      <li>role="list" for outermost ul</li>
+      <li>role="link" for each nav item's anchor</li>
+      <li>dynamic aria-expanded on each menu anchor</li>
+      <li>dynamic aria-current for menu anchors</li>
+      <li>properly relays expanded/collapsed state in VoiceOver links menu</li>
+      <li>submenu links are dynamically listed properly in VO links menu once they are expanded</li>
+      <li>Technology link launches an alertdialog</li>
+      <li>Entertainment link launches a status</li>
+      <li>Adjusting aria-live didn't have a noticable impact on UX for VO in any of the toast notifications</li>
+      <li>role="status" doesn't seem to report the status info the same way alertdialog does</li>
     </ul>
+
+    <!-- Variation 2, identify alertdialog with sr-only text after the icon -->
+    <!-- adding aria-describedby causes VO to read the message twice -->
+    <div
+      id="technology-warning"
+      aria-hidden="true"
+      aria-labelledby="technology-warning-title"
+      aria-live="polite"
+      role="alertdialog"
+      class="pf-c-toast pf-is-warning">
+      <div class="pf-c-toast__icon">
+        <i class="fas fa-home"></i>
+        <span id="technology-warning-title" class="sr-only">Technology Warning:</span>
+      </div>
+      <div id="technology-warning-message" class="pf-c-toast__message">
+        Technology is scary, are you sure you want to proceed?
+      </div>
+      <div class="pf-c-toast__action">
+        <a href="#">Continue</a>
+        <button data-dismiss aria-label="Dismiss Technology Warning" style="display:inline-block;">
+          <i class="fas fa-times"></i>
+        </button>
+      </div>
+    </div>
+
+    <!-- Variation 2, identify status with sr-only text after the icon -->
+    <!-- adding aria-describedby causes VO to read the message twice -->
+    <div
+      id="entertainment-info"
+      aria-hidden="true"
+      aria-labelledby="entertainment-success-title"
+      aria-describedby="entertainment-success-message"
+      aria-live="assertive"
+      role="status"
+      class="pf-c-toast pf-is-success">
+      <div class="pf-c-toast__icon">
+        <i class="fas fa-home"></i>
+        <span id="entertainment-success-title" class="sr-only">Entertainment Notification:</span>
+      </div>
+      <div id="entertainment-success-message" class="pf-c-toast__message">
+        Entertainment comes in many forms like music, art, and poetry.
+      </div>
+      <div class="pf-c-toast__action">
+        <a href="#">Close entertainment status</a>
+        <button data-dismiss aria-label="Dismiss Status Notification">
+          <i class="fas fa-times"></i>
+        </button>
+      </div>
+    </div>
+
   </main>
   <script src="https://code.jquery.com/jquery-3.3.1.js" integrity="sha256-2Kok7MbOyxpgUVvAk/HJ2jigOSYS2auK4Pfzbm7uH60=" crossorigin="anonymous"></script>
   <script src="js/navbar-list.js"></script>

--- a/navbar-menubar.html
+++ b/navbar-menubar.html
@@ -19,7 +19,6 @@
       <li class="pf-c-vertical-nav__item">
         <a
           href="#"
-          role="menuitem"
           class="pf-c-vertical-nav__link">
           <span class="pf-c-vertical-nav__link-icon"><i class="fas fa-home"></i></span>
           <span class="pf-c-vertical-nav__link-text">Home</span>
@@ -29,7 +28,6 @@
       <li class="pf-c-vertical-nav__item">
         <a
           href="#"
-          role="menuitem"
           class="pf-c-vertical-nav__link">
           <span class="pf-c-vertical-nav__link-icon"><i class="fas fa-home"></i></span>
           <span class="pf-c-vertical-nav__link-text">Technology</span>
@@ -39,7 +37,6 @@
       <li class="pf-c-vertical-nav__item">
         <a
           href="#"
-          role="link"
           aria-expanded="false"
           aria-controls="navbarSubmenu3"
           aria-current="false"
@@ -64,8 +61,7 @@
             <li class="pf-vertical-sub-nav__item">
               <a
                 href="#"
-                class="pf-vertical-sub-nav__link"
-                role="menuitem">
+                class="pf-vertical-sub-nav__link">
                 <span class="pf-c-vertical-nav__link-text">
                     Environmental Science
                 </span>
@@ -75,7 +71,6 @@
               <a
                 href="#"
                 aria-current="false"
-                role="menuitem"
                 class="pf-vertical-sub-nav__link">
                 <span class="pf-c-vertical-nav__link-text">
                   Physical Science
@@ -85,7 +80,6 @@
             <li class="pf-vertical-sub-nav__item">
               <a
                 href="#"
-                role="menuitem"
                 class="pf-vertical-sub-nav__link">
                 <span class="pf-c-vertical-nav__link-text">
                   Life Science
@@ -96,7 +90,6 @@
               <a
                 href="#"
                 aria-disabled="true"
-                role="menuitem"
                 class="pf-vertical-sub-nav__link pf-is-disabled">
                 Engineering
               </a>
@@ -111,7 +104,6 @@
           role="link"
           aria-expanded="false"
           aria-controls="navbarSubmenu4"
-          role="menuitem"
           class="pf-c-vertical-nav__link"
           id="navbarDropdownMenuLink4">
           <span class="pf-c-vertical-nav__link-icon">
@@ -130,7 +122,6 @@
             <li class="pf-vertical-sub-nav__item" aria-level="2">
               <a
                 href="#"
-                role="menuitem"
                 class="pf-vertical-sub-nav__link">
                 <span class="pf-c-vertical-nav__link-text">
                   Home Improvement
@@ -140,7 +131,6 @@
             <li class="pf-vertical-sub-nav__item" aria-level="2">
               <a
                 href="#"
-                role="menuitem"
                 class="pf-vertical-sub-nav__link">
                 <span class="pf-c-vertical-nav__link-text">
                   Lawn and Garden
@@ -150,7 +140,6 @@
             <li class="pf-vertical-sub-nav__item" aria-level="2">
               <a
                 href="#"
-                role="menuitem"
                 class="pf-vertical-sub-nav__link">
                 <span class="pf-c-vertical-nav__link-text">
                   Green Living
@@ -160,7 +149,6 @@
             <li class="pf-vertical-sub-nav__item" aria-level="2">
               <a
                 href="#"
-                role="menuitem"
                 aria-disabled="true"
                 class="pf-vertical-sub-nav__link pf-is-disabled">
                 Stain Removal
@@ -174,7 +162,6 @@
         <a
           href="#"
           aria-disabled="true"
-          role="menuitem"
           class="pf-c-vertical-nav__link pf-is-disabled">
           <span class="pf-c-vertical-nav__link-icon">
             <i class="fas fa-home"></i></span>
@@ -187,7 +174,6 @@
       <li class="pf-c-vertical-nav__item">
         <a
           href="#"
-          role="menuitem"
           class="pf-c-vertical-nav__link">
           <span class="pf-c-vertical-nav__link-icon"><i class="fas fa-home"></i></span>
           <span class="pf-c-vertical-nav__link-text">Entertainment</span>
@@ -202,8 +188,7 @@
       <li>features role="menuitem" on each menu anchor</li>
       <li>features dynamic aria-expanded on each menu anchor</li>
       <li>features dynamic aria-current on each menu anchor</li>
-      <li>seems to properly relay expanded/collapsed state in VoiceOver Form Controls menu</li>
-      <li>dynamically adds expanded links to the form controls menu as expected</li>
+      <li>properly relays expanded/collapsed state in VoiceOver Form Controls menu</li>
     </ul>
   </main>
   <script src="https://code.jquery.com/jquery-3.3.1.js" integrity="sha256-2Kok7MbOyxpgUVvAk/HJ2jigOSYS2auK4Pfzbm7uH60=" crossorigin="anonymous"></script>

--- a/sass/base.scss
+++ b/sass/base.scss
@@ -18,6 +18,13 @@ body {
   text-rendering: optimizeLegibility;
 }
 
+.nav-list-example {
+  // Keep visual interface and screen reader in lock-step
+  [aria-hidden="true"] {
+    display: none;
+  }
+}
+
 // VERTICAL NAV
 
 // // pf-c-block__element--modifier--state--PropiertyCamel
@@ -221,6 +228,4 @@ body {
     right: 0;
     left: auto;
   }
-
-
 }

--- a/single-notification.html
+++ b/single-notification.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Navigation Example</title>
+  <link rel="stylesheet" href="node_modules/normalize.css/normalize.css">
+  <link rel="stylesheet" href="css/base.css">
+  <script defer src="https://use.fontawesome.com/releases/v5.0.6/js/all.js"></script>
+</head>
+<body class="nav-list-example">
+
+  <header role="banner">
+    <h1>Navigation list launching submenus and notifications demo</h1>
+  </header>
+
+  <nav class="pf-c-vertical-nav">
+    <ul class="pf-c-vertical-nav__content" role="list">
+      <li class="pf-c-vertical-nav__item">
+
+        <a href="#" class="pf-c-vertical-nav__link">
+          <span class="pf-c-vertical-nav__link-icon"><i class="fas fa-home"></i></span>
+          <span class="pf-c-vertical-nav__link-text">Alert</span>
+        </a>
+      </li>
+
+      <li class="pf-c-vertical-nav__item">
+        <a href="#" class="pf-c-vertical-nav__link">
+          <span class="pf-c-vertical-nav__link-icon"><i class="fas fa-home"></i></span>
+          <span class="pf-c-vertical-nav__link-text">Alert Dialog</span>
+        </a>
+      </li>
+
+      <li class="pf-c-vertical-nav__item">
+        <a href="#" class="pf-c-vertical-nav__link">
+          <span class="pf-c-vertical-nav__link-icon"><i class="fas fa-home"></i></span>
+          <span class="pf-c-vertical-nav__link-text">Status</span>
+        </a>
+      </li>
+
+    </ul>
+  </nav>
+  <main>
+
+    <!-- Variation 2, identify alertdialog with sr-only text after the icon -->
+    <div
+      id="notification-element"
+      aria-hidden="true"
+      aria-labelledby="notification-element-title"
+      aria-describedby="notification-element-message"
+      class="pf-c-toast pf-is-warning">
+      <div class="pf-c-toast__icon">
+        <i class="fas fa-home"></i>
+        <span id="notification-element-title" class="sr-only">ALERT:</span>
+      </div>
+      <div id="notification-element-message" class="pf-c-toast__message">
+        Technology is scary, are you sure you want to proceed?
+      </div>
+      <div class="pf-c-toast__action">
+        <a href="#">Continue</a>
+        <button data-dismiss aria-label="Dismiss Notification" style="display:inline-block;">
+          <i class="fas fa-times"></i>
+        </button>
+      </div>
+    </div>
+
+  </main>
+  <script src="https://code.jquery.com/jquery-3.3.1.js" integrity="sha256-2Kok7MbOyxpgUVvAk/HJ2jigOSYS2auK4Pfzbm7uH60=" crossorigin="anonymous"></script>
+  <script src="js/single-notification.js"></script>
+</body>
+</html>

--- a/toast.html
+++ b/toast.html
@@ -1,6 +1,5 @@
 <!doctype html>
 <html>
-
 <head>
   <meta charset="utf-8">
   <title>CSS</title>


### PR DESCRIPTION
This PR adds an example menu that illustrates launching toast notifications as a result of selecting a navigation link. I used "Variation 2" of the toast notification.

Reusing a same DOM container ended up critical in being able to successfully make changes to the aria-live attribute.

Attached are a couple of helpful screenshots I found while researching this topic. Placing focus in the alert notification upon launch was another critical step toward getting the notification read aloud as expected.

Should help: https://github.com/patternfly/patternfly-next/issues/119

<img width="684" alt="screen shot 2018-04-05 at 2 23 21 pm" src="https://user-images.githubusercontent.com/5942899/38392429-7acaac96-38f5-11e8-9182-c066dfbacc8a.png">
<img width="664" alt="screen shot 2018-04-05 at 2 35 48 pm" src="https://user-images.githubusercontent.com/5942899/38392430-7adba9e2-38f5-11e8-8bcc-7182bc7100cd.png">
<img width="736" alt="screen shot 2018-04-05 at 2 36 49 pm" src="https://user-images.githubusercontent.com/5942899/38392431-7aeb58ec-38f5-11e8-9494-e1e4b4c0901e.png">
