### PR TITLE
add demo for managing focus control with pure html vs js

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -15,7 +15,7 @@ body {
   background-color: transparent;
   text-rendering: optimizeLegibility; }
 
-.nav-list-example [aria-hidden="true"] {
+.nav-list-example [aria-hidden="true"]:not(.svg-inline--fa) {
   display: none; }
 
 @media (min-width: 50rem) {

--- a/focus-flow.html
+++ b/focus-flow.html
@@ -1,0 +1,86 @@
+<!doctype html>
+<html lang="en-US">
+<head>
+  <meta charset="utf-8">
+  <title>Focus Flow Example</title>
+</head>
+<body class="nav-list-example">
+  <main>
+
+    <header role="banner">
+      <h1>Focus flow with named anchors</h1>
+      <p>This page tests the default behavior for navigating, via named anchors or "hot links", to sections of content that are, in various ways, "hidden". Before selecting the links below, first tab through the elements on this page and notice the order in which elements receive focus, in particular, notice how the "Focusable Element" link receives focus in a standard fashion just by existing inline with the rest of the page content.</p>
+      <p>Then, notice how selecting a link from the navigation changes the focus index which ultimately changes what item receives focus next when tabbing through the interface.</p>
+    </header>
+
+    <nav id="back-to-nav">
+      <a role="link" href="#display-none">Navigate to "display none" section</a><br>
+      <a role="link" href="#hidden">Navigate to "hidden" section</a><br>
+      <a role="link" href="#aria-hidden">Navigate to "aria-hidden" section</a>
+    </nav>
+
+    <a href="#" role="link" style="margin-top:25px;display:inline-block;">*Focusable Element</a>
+
+    <h4>Navigating to a "display: none" element using named anchors</h4>
+    <p>In this scenario, we find that because the target element is hidden from view, there is no way for the browser to calculate what the new scroll position should be, so it simply doesn't scroll anywhere, which would otherwise be the default browser behavior.</p>
+    <ul>
+      <li>target element doesn't receive focus</li>
+      <li>tab index is affected</li>
+      <li>doesn't scroll</li>
+    </ul>
+
+    <h4>Navigating to a "hidden" element using named anchors</h4>
+    <p>This has an almost identical experience of navigating to a "display none" element. Scroll position isn't affected and even though the target element is hidden and not able to receive focus, the focus index is impacted. For example, notice that after selecting the link to navigate to the "hidden" section, the next press of the tab shifts focus to the next focusable element in the DOM <em>following</em> the "hidden" section's container, and <i>not</i> the next focusable element following the link the selected, which in this case would be the "*Focusable Element" link.</i></em></p>
+    <ul>
+      <li>target element doesn't receive focus</li>
+      <li>tab index is affected</li>
+      <li>doesn't scroll</li>
+    </ul>
+
+    <h4>Navigating to a "aria-hidden" element using named anchors</h4>
+    <p>What's interesting here is that even though the target element is hidden from accessibility tooling, it remains in view as most user agent stylesheets do not automatically hide elements just because this property (aria-hidden) is set. As such, any focusable elements that exist within this example container will be next in the tab flow queue.</p>
+    <ul>
+      <li>target element will receive focus</li>
+      <li>tab index is affected</li>
+      <li>does scroll to target container</li>
+      <li>focusable elements within the target element will come next in the tab index queue</li>
+    </ul>
+
+    <h4>Takeaways</h4>
+    <ol>
+      <li>In all cases, when selecting a link that utilizes a named anchor, the underlying tab index is shifted. Focus flow moves to the point in the source where the target element exists. If the target element has focusable children, they will become the next focusable item, otherwise picking up on whatever comes next in the documents source order.</li>
+      <li>To control the focus flow from purely an HTML perspective, we must ensure the target element is visible in the sense that it's display property isn't set to "none" and it doesn't feature a "hidden" property.</li>
+    </ol>
+
+    <div style="border:1px solid black;">
+      <section id="hidden" hidden>
+        <h4>This section applies the [hidden] attribute to its container</h4>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+      </section>
+
+      <section id="aria-hidden" aria-hidden="true">
+        <h4>This section applies the [aria-hidden] attribute to its container</h4>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+      </section>
+
+      <section id="display-none" style="display:none;">
+        <h4>This section sets the display property to "none" on its container</h4>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+      </section>
+
+      <a href="#back-to-nav" role="link">Back to navigation</a>
+    </div>
+
+    <ul>
+      <li><a href="#" role="link">Next focusable link - 02</a></li>
+      <li><a href="#" role="link">Next focusable link - 03</a></li>
+      <li><a href="#" role="link">Next focusable link - 04</a></li>
+      <li><a href="#" role="link">Next focusable link - 05</a></li>
+      <li><a href="#" role="link">Next focusable link - 06</a></li>
+      <li><a href="#" role="link">Next focusable link - 07</a></li>
+      <li><a href="#" role="link">Next focusable link - 08</a></li>
+    </ul>
+
+  </main>
+</body>
+</html>

--- a/focus-flow.html
+++ b/focus-flow.html
@@ -16,7 +16,12 @@
     <nav id="back-to-nav">
       <a role="link" href="#display-none">Navigate to "display none" section</a><br>
       <a role="link" href="#hidden">Navigate to "hidden" section</a><br>
-      <a role="link" href="#aria-hidden">Navigate to "aria-hidden" section</a>
+      <a role="link" href="#aria-hidden">Navigate to "aria-hidden" section</a><br>
+      <a role="link" href="#visible">Navigate to a visible section</a><br>
+      <a
+        role="link"
+        href="#aria-controls-visible"
+        aria-controls="aria-controls-visible">Aria-controls a visible section</a>
     </nav>
 
     <a href="#" role="link" style="margin-top:25px;display:inline-block;">*Focusable Element</a>
@@ -50,6 +55,7 @@
     <ol>
       <li>In all cases, when selecting a link that utilizes a named anchor, the underlying tab index is shifted. Focus flow moves to the point in the source where the target element exists. If the target element has focusable children, they will become the next focusable item, otherwise picking up on whatever comes next in the documents source order.</li>
       <li>To control the focus flow from purely an HTML perspective, we must ensure the target element is visible in the sense that it's display property isn't set to "none" and it doesn't feature a "hidden" property.</li>
+      <li>Using aria-controls along with named anchors has a default behavior of displaying a "Jump" menu in VO. This information is doubled up when presented.</li>
     </ol>
 
     <div style="border:1px solid black;">
@@ -68,6 +74,16 @@
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
       </section>
 
+      <section id="visible">
+        <h4>This section represents a standard visible element</h4>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+      </section>
+
+      <section id="aria-controls-visible">
+        <h4>This section is bound by aria-controls</h4>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+      </section>
+
       <a href="#back-to-nav" role="link">Back to navigation</a>
     </div>
 
@@ -75,10 +91,6 @@
       <li><a href="#" role="link">Next focusable link - 02</a></li>
       <li><a href="#" role="link">Next focusable link - 03</a></li>
       <li><a href="#" role="link">Next focusable link - 04</a></li>
-      <li><a href="#" role="link">Next focusable link - 05</a></li>
-      <li><a href="#" role="link">Next focusable link - 06</a></li>
-      <li><a href="#" role="link">Next focusable link - 07</a></li>
-      <li><a href="#" role="link">Next focusable link - 08</a></li>
     </ul>
 
   </main>

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
       <li><a href="toast.html">Toast</a></li>
       <li><a href="kebab.html">Kebab</a></li>
       <li><a href="kebab2.html">Kebab 2</a></li>
+      <li><a href="focus-flow.html">Focus flow with named anchors</a></li>
     </ul>
 
   </body>

--- a/sass/base.scss
+++ b/sass/base.scss
@@ -20,7 +20,7 @@ body {
 
 .nav-list-example {
   // Keep visual interface and screen reader in lock-step
-  [aria-hidden="true"] {
+  [aria-hidden="true"]:not(.svg-inline--fa) {
     display: none;
   }
 }


### PR DESCRIPTION
This PR adds a demo page that illustrates default browser behavior when using named anchors (`href="#some-content"`) to link to content which is hidden in various ways.