### PR TITLE
Refactor examples to use a single notification container

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -15,18 +15,15 @@ body {
   background-color: transparent;
   text-rendering: optimizeLegibility; }
 
-.nav-list-example [aria-hidden="true"]:not(.svg-inline--fa) {
-  display: none; }
-
-.nav-list-example .flexContainer {
+.flexContainer {
   display: -ms-flexbox;
   display: flex; }
 
-.nav-list-example .flexSpaceAround {
+.flexSpaceAround {
   -ms-flex-pack: distribute;
       justify-content: space-around; }
 
-.nav-list-example .col {
+.col {
   width: 44%;
   border: 1px solid #777777;
   border-radius: 8px;
@@ -71,7 +68,7 @@ body {
 
 .pf-vertical-sub-nav {
   display: none; }
-  .pf-vertical-sub-nav:not([aria-hidden="true"]) {
+  .pf-vertical-sub-nav.pf-is-open:not([hidden]) {
     display: block; }
 
 @media (min-width: 50rem) {

--- a/focus-flow.html
+++ b/focus-flow.html
@@ -3,8 +3,11 @@
 <head>
   <meta charset="utf-8">
   <title>Focus Flow Example</title>
+  <link rel="stylesheet" href="node_modules/normalize.css/normalize.css">
+  <link rel="stylesheet" href="css/base.css">
+  <script defer src="https://use.fontawesome.com/releases/v5.0.6/js/all.js"></script>
 </head>
-<body class="nav-list-example">
+<body>
   <main>
 
     <header role="banner">
@@ -13,85 +16,91 @@
       <p>Then, notice how selecting a link from the navigation changes the focus index which ultimately changes what item receives focus next when tabbing through the interface.</p>
     </header>
 
-    <nav id="back-to-nav">
-      <a role="link" href="#display-none">Navigate to "display none" section</a><br>
-      <a role="link" href="#hidden">Navigate to "hidden" section</a><br>
-      <a role="link" href="#aria-hidden">Navigate to "aria-hidden" section</a><br>
-      <a role="link" href="#visible">Navigate to a visible section</a><br>
-      <a
-        role="link"
-        href="#aria-controls-visible"
-        aria-controls="aria-controls-visible">Aria-controls a visible section</a>
-    </nav>
+    <div class="flexContainer flexSpaceAround">
+      <div class="col">
+        <nav id="main -nav">
+          <a role="link" href="#display-none">Navigate to "display none" section</a><br>
+          <a role="link" href="#hidden">Navigate to "hidden" section</a><br>
+          <a role="link" href="#aria-hidden">Navigate to "aria-hidden" section</a><br>
+          <a role="link" href="#visible">Navigate to a visible section</a><br>
+          <a
+            role="link"
+            href="#aria-controls-visible"
+            aria-controls="aria-controls-visible">Aria-controls a visible section</a>
+        </nav>
 
-    <a href="#" role="link" style="margin-top:25px;display:inline-block;">*Focusable Element</a>
+        <a href="#" role="link" style="margin-top:25px;display:inline-block;">*Focusable Element</a>
 
-    <h4>Navigating to a "display: none" element using named anchors</h4>
-    <p>In this scenario, we find that because the target element is hidden from view, there is no way for the browser to calculate what the new scroll position should be, so it simply doesn't scroll anywhere, which would otherwise be the default browser behavior.</p>
-    <ul>
-      <li>target element doesn't receive focus</li>
-      <li>tab index is affected</li>
-      <li>doesn't scroll</li>
-    </ul>
+        <div style="border:1px solid black;">
+          <section id="display-none" style="display:none;">
+            <h4>This section has the display property set to "none" on its container</h4>
+            <p>This has the effect of now allowing one to </p>
+          </section>
 
-    <h4>Navigating to a "hidden" element using named anchors</h4>
-    <p>This has an almost identical experience of navigating to a "display none" element. Scroll position isn't affected and even though the target element is hidden and not able to receive focus, the focus index is impacted. For example, notice that after selecting the link to navigate to the "hidden" section, the next press of the tab shifts focus to the next focusable element in the DOM <em>following</em> the "hidden" section's container, and <i>not</i> the next focusable element following the link the selected, which in this case would be the "*Focusable Element" link.</i></em></p>
-    <ul>
-      <li>target element doesn't receive focus</li>
-      <li>tab index is affected</li>
-      <li>doesn't scroll</li>
-    </ul>
+          <section id="hidden" hidden>
+            <h4>This section applies the [hidden] attribute to its container</h4>
+            <p>User agent stylesheets hide elements with the "hidden" attribute by default. This has the effect of both hiding them from view as well as hiding those elements from screen readers.</p>
+          </section>
 
-    <h4>Navigating to a "aria-hidden" element using named anchors</h4>
-    <p>What's interesting here is that even though the target element is hidden from accessibility tooling, it remains in view as most user agent stylesheets do not automatically hide elements just because this property (aria-hidden) is set. As such, any focusable elements that exist within this example container will be next in the tab flow queue.</p>
-    <ul>
-      <li>target element will receive focus</li>
-      <li>tab index is affected</li>
-      <li>does scroll to target container</li>
-      <li>focusable elements within the target element will come next in the tab index queue</li>
-    </ul>
+          <section id="aria-hidden" aria-hidden="true">
+            <h4>This section applies the [aria-hidden] attribute to its container</h4>
+            <p>The attribute aria-hidden alone, reguarless of its set value, does not hide an element from view.</p>
+          </section>
 
-    <h4>Takeaways</h4>
-    <ol>
-      <li>In all cases, when selecting a link that utilizes a named anchor, the underlying tab index is shifted. Focus flow moves to the point in the source where the target element exists. If the target element has focusable children, they will become the next focusable item, otherwise picking up on whatever comes next in the documents source order.</li>
-      <li>To control the focus flow from purely an HTML perspective, we must ensure the target element is visible in the sense that it's display property isn't set to "none" and it doesn't feature a "hidden" property.</li>
-      <li>Using aria-controls along with named anchors has a default behavior of displaying a "Jump" menu in VO. This information is doubled up when presented.</li>
-    </ol>
+          <section id="visible">
+            <h4>This section represents a standard visible element</h4>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+          </section>
 
-    <div style="border:1px solid black;">
-      <section id="hidden" hidden>
-        <h4>This section applies the [hidden] attribute to its container</h4>
-        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-      </section>
+          <section id="aria-controls-visible">
+            <h4>This section is bound by aria-controls</h4>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+          </section>
 
-      <section id="aria-hidden" aria-hidden="true">
-        <h4>This section applies the [aria-hidden] attribute to its container</h4>
-        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-      </section>
+          <a href="#main-nav" role="link">Back to navigation</a>
+        </div>
 
-      <section id="display-none" style="display:none;">
-        <h4>This section sets the display property to "none" on its container</h4>
-        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-      </section>
+        <ul>
+          <li><a href="#" role="link">Next focusable link - 02</a></li>
+          <li><a href="#" role="link">Next focusable link - 03</a></li>
+          <li><a href="#" role="link">Next focusable link - 04</a></li>
+        </ul>
+      </div><!-- .col -->
 
-      <section id="visible">
-        <h4>This section represents a standard visible element</h4>
-        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-      </section>
+      <div class="col">
+        <h4>Navigating to a "display: none" element using named anchors</h4>
+        <p>In this scenario, we find that because the target element is hidden from view, there is no way for the browser to calculate what the new scroll position should be, so it simply doesn't scroll anywhere, which would otherwise be the default browser behavior.</p>
+        <ul>
+          <li>target element doesn't receive focus</li>
+          <li>tab index is affected</li>
+          <li>doesn't scroll</li>
+        </ul>
 
-      <section id="aria-controls-visible">
-        <h4>This section is bound by aria-controls</h4>
-        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-      </section>
+        <h4>Navigating to a "hidden" element using named anchors</h4>
+        <p>This has an almost identical experience of navigating to a "display none" element. Scroll position isn't affected and even though the target element is hidden and not able to receive focus, the focus index is impacted. For example, notice that after selecting the link to navigate to the "hidden" section, the next press of the tab shifts focus to the next focusable element in the DOM <em>following</em> the "hidden" section's container, and <i>not</i> the next focusable element following the link the selected, which in this case would be the "*Focusable Element" link.</i></em></p>
+        <ul>
+          <li>target element doesn't receive focus</li>
+          <li>tab index is affected</li>
+          <li>doesn't scroll</li>
+        </ul>
 
-      <a href="#back-to-nav" role="link">Back to navigation</a>
+        <h4>Navigating to a "aria-hidden" element using named anchors</h4>
+        <p>What's interesting here is that even though the target element is hidden from accessibility tooling, it remains in view as most user agent stylesheets do not automatically hide elements just because this property (aria-hidden) is set. As such, any focusable elements that exist within this example container will be next in the tab flow queue.</p>
+        <ul>
+          <li>target element will receive focus</li>
+          <li>tab index is affected</li>
+          <li>does scroll to target container</li>
+          <li>focusable elements within the target element will come next in the tab index queue</li>
+        </ul>
+
+        <h4>Takeaways</h4>
+        <ol>
+          <li>In all cases, when selecting a link that utilizes a named anchor, the underlying tab index is shifted. Focus flow moves to the point in the source where the target element exists. If the target element has focusable children, they will become the next focusable item, otherwise picking up on whatever comes next in the documents source order.</li>
+          <li>To control the focus flow from purely an HTML perspective, we must ensure the target element is visible in the sense that it's display property isn't set to "none" and it doesn't feature a "hidden" property.</li>
+          <li>Using aria-controls along with named anchors has a default behavior of displaying a "Jump" menu in VO. This information is doubled up when presented.</li>
+        </ol>
+      </div><!-- .col -->
     </div>
-
-    <ul>
-      <li><a href="#" role="link">Next focusable link - 02</a></li>
-      <li><a href="#" role="link">Next focusable link - 03</a></li>
-      <li><a href="#" role="link">Next focusable link - 04</a></li>
-    </ul>
 
   </main>
 </body>

--- a/js/navbar-list.js
+++ b/js/navbar-list.js
@@ -6,8 +6,7 @@
   },
 
   hasSubmenu = function ($menuItem) {
-    // if the menu item has a sub-menu, it will have a value for [aria-controls]
-    return !!$menuItem.attr('aria-controls');
+    return !!$menuItem.find('+ section').length;
   },
 
   subMenuIsVisible = function ($subMenu) {
@@ -15,20 +14,22 @@
   },
 
   hideEl = function ($element) {
-    $element.attr('aria-hidden', true);
+    $element.attr('hidden', 'hidden');
   },
 
   showEl = function ($element) {
-    $element.attr('aria-hidden', false);
+    $element.removeAttr('hidden');
   },
 
   openMenu = function ($menuItem, $subMenu) {
     $menuItem.attr('aria-expanded', true);
+    $subMenu.addClass('pf-is-open');
     showEl($subMenu);
   },
 
   closeMenu = function ($menuItem, $subMenu) {
     $menuItem.attr('aria-expanded', false);
+    $subMenu.removeClass('pf-is-open');
     hideEl($subMenu);
   },
 
@@ -40,15 +41,14 @@
     $element.find('a:first').trigger('focus');
   },
 
-  getSubMenu = function ($menuItem) {
-    let subMenuSelector = '#' + $menuItem.attr('aria-controls');
-    return $(subMenuSelector);
+  getSubMenu = function ($listItem) {
+    return $listItem.find('> a + section');
   },
 
   closeOpenMenus = function ($menuItems) {
     $.each($menuItems, function (idx, item) {
       if (getMenuItemLnk(item).attr('aria-expanded') === 'true') {
-        let $subMenu = getSubMenu(getMenuItemLnk(item));
+        let $subMenu = getSubMenu($(item));
         closeMenu(getMenuItemLnk(item), $subMenu);
       }
     });
@@ -71,7 +71,68 @@
   },
 
   popNotification = function ($element) {
-    showEl($element);
+    $('main').append($element);
+
+    setTimeout(function () {
+      $element.remove();
+    }, 6000);
+  },
+
+  technologyWarningMarkup = function () {
+    return `
+      <div
+        id="technology-warning"
+        class="pf-c-toast pf-is-warning">
+        <div
+          role="alert"
+          aria-live="assertive">
+
+          <div class="pf-c-toast__icon">
+            <i class="fas fa-home"></i>
+            <span id="technology-warning-title" class="sr-only">Warning message:</span>
+          </div>
+
+          <div id="technology-warning-message" class="pf-c-toast__message">
+            Technology is scary, and may include topics that are confusing.
+          </div>
+
+        </div>
+        <div class="pf-c-toast__action">
+          <a href="#">Exclude Confusing Topics</a>
+          <button data-dismiss aria-label="Dismiss Notification">
+            <i class="fas fa-times"></i>
+          </button>
+        </div>
+      </div>
+    `;
+  },
+
+  entertainmentInfoMarkup = function () {
+    return `
+      <div
+        id="entertainment-info"
+        class="pf-c-toast pf-is-success">
+        <div
+          role="alert"
+          aria-live="polite">
+
+          <div class="pf-c-toast__icon">
+            <i class="fas fa-home"></i>
+            <span id="entertainment-success-title" class="sr-only">Success message:</span>
+          </div>
+
+          <div id="entertainment-success-message" class="pf-c-toast__message">
+            Entertainment comes in many forms like music, art, and poetry.
+          </div>
+
+        </div>
+        <div class="pf-c-toast__action">
+          <button data-dismiss aria-label="Dismiss Notification">
+            <i class="fas fa-times"></i>
+          </button>
+        </div>
+      </div>
+    `;
   },
 
   bindMenuEvents = function ($listItem, idx, $menuItems) {
@@ -80,7 +141,7 @@
     $menuItem.on('focus click focusout focusin', function (event) {
       event.preventDefault();
 
-      let $subMenu = getSubMenu($menuItem);
+      let $subMenu = getSubMenu($listItem);
 
       switch (event.type) {
 
@@ -91,7 +152,7 @@
             event.stopImmediatePropagation();
 
             if (hasSubmenu($menuItem)) {
-              if ($subMenu.attr('aria-hidden') === 'true') {
+              if ($subMenu.attr('hidden') === 'hidden') {
 
                 // first close any subMenus that are already open
                 closeOpenMenus($menuItems);
@@ -113,19 +174,11 @@
 
               switch (menuItemTxt) {
                 case 'Technology': {
-                  popNotification($('#technology-warning'));
-                  setTimeout(function () {
-                    hideEl($('#technology-warning'));
-                  }, 8000);
-                  focusFirstMenuItem($('#technology-warning'));
+                  popNotification($(technologyWarningMarkup()));
                   break;
                 }
                 case 'Entertainment': {
-                  popNotification($('#entertainment-info'));
-                  setTimeout(function () {
-                    hideEl($('#entertainment-info'));
-                  }, 8000);
-                  // focusFirstMenuItem($('#entertainment-info')); // don't do this for role="status"!!
+                  popNotification($(entertainmentInfoMarkup()));
                   break;
                 }
                 default: {}

--- a/js/navbar-menubar.js
+++ b/js/navbar-menubar.js
@@ -16,12 +16,14 @@
 
   openMenu = function ($menuItem, $subMenu) {
     $menuItem.attr('aria-expanded', true);
-    $subMenu.attr('aria-hidden', false);
+    $subMenu.addClass('pf-is-open');
+    $subMenu.removeAttr('hidden');
   },
 
   closeMenu = function ($menuItem, $subMenu) {
     $menuItem.attr('aria-expanded', false);
-    $subMenu.attr('aria-hidden', true);
+    $subMenu.removeClass('pf-is-open');
+    $subMenu.attr('hidden', 'hidden');
   },
 
   getMenuItemLnk = function (item) {
@@ -79,8 +81,7 @@
             event.stopImmediatePropagation();
 
             if (hasSubmenu($menuItem)) {
-              if ($subMenu.attr('aria-hidden') === 'true') {
-
+              if ($subMenu.attr('hidden') === 'hidden') {
                 // first close any subMenus that are already open
                 closeOpenMenus($menuItems);
 

--- a/js/submenu-flow-js.js
+++ b/js/submenu-flow-js.js
@@ -14,29 +14,27 @@
   },
 
   hideEl = function ($element) {
-    $element.attr('aria-hidden', true);
+    $element.attr('hidden', 'hidden');
   },
 
   showEl = function ($element) {
-    $element.attr('aria-hidden', false);
+    $element.removeAttr('hidden');
   },
 
   openMenu = function ($menuItem, $subMenu) {
     $menuItem.attr('aria-expanded', true);
+    $subMenu.addClass('pf-is-open');
     showEl($subMenu);
   },
 
   closeMenu = function ($menuItem, $subMenu) {
     $menuItem.attr('aria-expanded', false);
+    $subMenu.removeClass('pf-is-open');
     hideEl($subMenu);
   },
 
   getMenuItemLnk = function (item) {
     return $(item).find('> a');
-  },
-
-  focusFirstMenuItem = function ($element) {
-    $element.find('a:first').trigger('focus');
   },
 
   getSubMenu = function ($listItem) {
@@ -89,13 +87,12 @@
             event.stopImmediatePropagation();
 
             if (hasSubmenu($menuItem)) {
-              if ($subMenu.attr('aria-hidden') === 'true') {
+              if ($subMenu.attr('hidden') === 'hidden') {
 
                 // first close any subMenus that are already open
                 closeOpenMenus($menuItems);
 
                 openMenu($menuItem, $subMenu);
-                focusFirstMenuItem($subMenu);
               } else {
                 closeMenu($menuItem, $subMenu);
               }

--- a/js/submenu-flow.js
+++ b/js/submenu-flow.js
@@ -14,20 +14,22 @@
   },
 
   hideEl = function ($element) {
-    $element.attr('aria-hidden', true);
+    $element.attr('hidden', 'hidden');
   },
 
   showEl = function ($element) {
-    $element.attr('aria-hidden', false);
+    $element.removeAttr('hidden');
   },
 
   openMenu = function ($menuItem, $subMenu) {
     $menuItem.attr('aria-expanded', true);
+    $subMenu.addClass('pf-is-open');
     showEl($subMenu);
   },
 
   closeMenu = function ($menuItem, $subMenu) {
     $menuItem.attr('aria-expanded', false);
+    $subMenu.removeClass('pf-is-open');
     hideEl($subMenu);
   },
 
@@ -82,7 +84,7 @@
           $menuItem.on('click', function (event) {
 
             if (hasSubmenu($menuItem)) {
-              if ($subMenu.attr('aria-hidden') === 'true') {
+              if ($subMenu.attr('hidden') === 'hidden') {
 
                 // first close any subMenus that are already open
                 closeOpenMenus($menuItems);

--- a/js/visible-submenu-flow.js
+++ b/js/visible-submenu-flow.js
@@ -14,20 +14,22 @@
   },
 
   hideEl = function ($element) {
-    $element.attr('aria-hidden', true);
+    $element.attr('hidden', 'hidden');
   },
 
   showEl = function ($element) {
-    $element.attr('aria-hidden', false);
+    $element.removeAttr('hidden');
   },
 
   openMenu = function ($menuItem, $subMenu) {
     $menuItem.attr('aria-expanded', true);
+    $subMenu.parents('section').addClass('pf-is-open');
     showEl($subMenu);
   },
 
   closeMenu = function ($menuItem, $subMenu) {
     $menuItem.attr('aria-expanded', false);
+    $subMenu.parents('section').removeClass('pf-is-open');
     hideEl($subMenu);
   },
 
@@ -82,9 +84,7 @@
           $menuItem.on('click', function (event) {
 
             if (hasSubmenu($menuItem)) {
-              console.log('has submenu');
-              if ($subMenu.attr('aria-hidden') === 'true') {
-                console.log('submenu is hidden');
+              if ($subMenu.attr('hidden') === 'hidden') {
 
                 // first close any subMenus that are already open
                 closeOpenMenus($menuItems);

--- a/navbar-list.html
+++ b/navbar-list.html
@@ -13,222 +13,189 @@
     <h1>Navigation list launching submenus and notifications demo</h1>
   </header>
 
-  <nav class="pf-c-vertical-nav">
-    <ul class="pf-c-vertical-nav__content" role="list">
-      <li class="pf-c-vertical-nav__item">
+  <div class="flexContainer flexSpaceAround">
+      <div class="col">
+        <nav class="pf-c-vertical-nav">
+            <ul class="pf-c-vertical-nav__content" role="list">
+              <li class="pf-c-vertical-nav__item">
 
-        <!-- JS NOTES for any <a> menu item that DOES NOT have a submenu-->
-        <!-- aria-current= -->
-        <!-- "true" when this menu item is the current page (i.e. active) -->
-        <!-- "false" when any other menu item is the current page -->
+                <!-- JS NOTES for any <a> menu item that DOES NOT have a submenu-->
+                <!-- aria-current= -->
+                <!-- "true" when this menu item is the current page (i.e. active) -->
+                <!-- "false" when any other menu item is the current page -->
 
-        <a href="#" class="pf-c-vertical-nav__link">
-          <span class="pf-c-vertical-nav__link-icon"><i class="fas fa-home"></i></span>
-          <span class="pf-c-vertical-nav__link-text">Home</span>
-        </a>
-      </li>
+                <a href="#" class="pf-c-vertical-nav__link">
+                  <span class="pf-c-vertical-nav__link-icon"><i class="fas fa-home"></i></span>
+                  <span class="pf-c-vertical-nav__link-text">Home</span>
+                </a>
+              </li>
 
-      <li class="pf-c-vertical-nav__item">
-        <a href="#" class="pf-c-vertical-nav__link">
-          <span class="pf-c-vertical-nav__link-icon"><i class="fas fa-home"></i></span>
-          <span class="pf-c-vertical-nav__link-text">Technology</span>
-        </a>
-      </li>
+              <li class="pf-c-vertical-nav__item">
+                <a href="#" class="pf-c-vertical-nav__link">
+                  <span class="pf-c-vertical-nav__link-icon"><i class="fas fa-home"></i></span>
+                  <span class="pf-c-vertical-nav__link-text">Technology</span>
+                </a>
+              </li>
 
-      <li class="pf-c-vertical-nav__item">
+              <li class="pf-c-vertical-nav__item">
 
-        <!-- JS NOTES for any <a> menu item that DOES have a submenu-->
+                <!-- JS NOTES for any <a> menu item that DOES have a submenu-->
 
-        <!-- aria-expanded="true" when the submenu is visible -->
-        <!-- aria-expanded="false" when the submenu is hidden -->
+                <!-- aria-expanded="true" when the submenu is visible -->
+                <!-- aria-expanded="false" when the submenu is hidden -->
 
-        <!-- aria-current="true" when a menu item in the submenu is the current page (i.e. active) -->
-        <!-- aria-current="false" when any other menu item is the current page -->
-        <!-- except, this doesn't work in Voiceover on Mac - instead only the first aria-current attribute is recognized. Is it too much to transfer this attribute dynamically depending on menu visibility? so when the menu is hidden, the parent has ariaa-current and when the menu is visible the submenu item has aria-current -->
+                <!-- aria-current="true" when a menu item in the submenu is the current page (i.e. active) -->
+                <!-- aria-current="false" when any other menu item is the current page -->
+                <!-- except, this doesn't work in Voiceover on Mac - instead only the first aria-current attribute is recognized. Is it too much to transfer this attribute dynamically depending on menu visibility? so when the menu is hidden, the parent has ariaa-current and when the menu is visible the submenu item has aria-current -->
 
-        <a
-          href="#"
-          aria-expanded="false"
-          aria-controls="navbarSubmenu3"
-          aria-current="false"
-          class="pf-c-vertical-nav__link"
-          id="navbarDropdownMenuLink3"> <!-- pf-is-active class is added to links that are open -->
-          <span class="pf-c-vertical-nav__link-icon">
-            <i class="fas fa-home"></i>
-          </span>
-          <span class="pf-c-vertical-nav__link-text">
-            Science
-          </span>
-        </a>
+                <a
+                  href="#"
+                  aria-expanded="false"
+                  aria-controls="navbarSubmenu3"
+                  aria-current="false"
+                  class="pf-c-vertical-nav__link"
+                  id="navbarDropdownMenuLink3"> <!-- pf-is-active class is added to links that are open -->
+                  <span class="pf-c-vertical-nav__link-icon">
+                    <i class="fas fa-home"></i>
+                  </span>
+                  <span class="pf-c-vertical-nav__link-text">
+                    Science
+                  </span>
+                </a>
 
-        <!-- JS NOTES for submenus -->
-        <!-- aria-hidden="true" when the submenu is not visible -->
-        <!-- aria-hidden="false" (or not included) when the submenu is visible -->
-        <section
-          class="pf-vertical-sub-nav"
-          aria-hidden="true"
-          aria-labelledby="navbarDropdownMenuLink3"
-          id="navbarSubmenu3"> <!-- pf-is-open class is added to sections that are open -->
-          <h2 class="pf-vertical-sub-nav__title">Science</h2>
-          <ul class="pf-vertical-sub-nav__content">
-            <li class="pf-vertical-sub-nav__item">
-              <a href="#" class="pf-vertical-sub-nav__link">
-                <span class="pf-c-vertical-nav__link-text">
-                    Environmental Science
-                </span>
-              </a>
-            </li>
-            <li class="pf-vertical-sub-nav__item">
+                <!-- JS NOTES for submenus -->
+                <!-- hidden or hidden="hidden" when the submenu is not visible -->
+                <!-- hidden attribute should be removed when the submenu is visible -->
+                <section
+                  class="pf-vertical-sub-nav"
+                  hidden
+                  aria-labelledby="navbarDropdownMenuLink3"
+                  id="navbarSubmenu3"> <!-- pf-is-open class is added to sections that are open -->
+                  <h2 class="pf-vertical-sub-nav__title">Science</h2>
+                  <ul class="pf-vertical-sub-nav__content">
+                    <li class="pf-vertical-sub-nav__item">
+                      <a href="#" class="pf-vertical-sub-nav__link">
+                        <span class="pf-c-vertical-nav__link-text">
+                            Environmental Science
+                        </span>
+                      </a>
+                    </li>
+                    <li class="pf-vertical-sub-nav__item">
 
-              <!-- JS NOTES for any <a> menu item that IS IN a submenu-->
-              <!-- aria-current="true" when this menu item is the current page (i.e. active) -->
-              <!-- aria-current="false" when any other menu item is the current page -->
-              <a href="#" aria-current="false" class="pf-vertical-sub-nav__link">
-                <span class="pf-c-vertical-nav__link-text">
-                  Physical Science
-                </span>
-              </a>
-            </li>
-            <li class="pf-vertical-sub-nav__item">
-              <a href="#" class="pf-vertical-sub-nav__link">
-                <span class="pf-c-vertical-nav__link-text">
-                  Life Science
-                </span>
-              </a>
-            </li>
-            <li class="pf-vertical-sub-nav__item">
-              <a href="#" aria-disabled="true" class="pf-vertical-sub-nav__link pf-is-disabled">Engineering</a>
-            </li>
+                      <!-- JS NOTES for any <a> menu item that IS IN a submenu-->
+                      <!-- aria-current="true" when this menu item is the current page (i.e. active) -->
+                      <!-- aria-current="false" when any other menu item is the current page -->
+                      <a href="#" aria-current="false" class="pf-vertical-sub-nav__link">
+                        <span class="pf-c-vertical-nav__link-text">
+                          Physical Science
+                        </span>
+                      </a>
+                    </li>
+                    <li class="pf-vertical-sub-nav__item">
+                      <a href="#" class="pf-vertical-sub-nav__link">
+                        <span class="pf-c-vertical-nav__link-text">
+                          Life Science
+                        </span>
+                      </a>
+                    </li>
+                    <li class="pf-vertical-sub-nav__item">
+                      <a href="#" aria-disabled="true" class="pf-vertical-sub-nav__link pf-is-disabled">Engineering</a>
+                    </li>
+                  </ul>
+                </section>
+              </li>
+
+              <li class="pf-c-vertical-nav__item">
+                <a
+                  href="#"
+                  aria-expanded="false"
+                  aria-controls="navbarSubmenu4"
+                  class="pf-c-vertical-nav__link"
+                  id="navbarDropdownMenuLink4">
+                  <span class="pf-c-vertical-nav__link-icon">
+                    <i class="fas fa-home"></i>
+                  </span>
+                  <span class="pf-c-vertical-nav__link-text">Home and Garden</span>
+                </a>
+
+                <!-- HTML NOTES
+                The following menu has a variation, where aria-level is used to identify list level
+                Aside from the additional aria attribute, the JS updates should be the same for this section -->
+                <section
+                  class="pf-vertical-sub-nav"
+                  aria-labelledby="navbarDropdownMenuLink4"
+                  id="navbarSubmenu4"
+                  hidden>
+                  <h2 class="pf-vertical-sub-nav__title">Home and Garden</h2>
+                  <ul class="pf-vertical-sub-nav__content">
+                    <li class="pf-vertical-sub-nav__item" aria-level="2">
+                      <a href="#" class="pf-vertical-sub-nav__link">
+                        <span class="pf-c-vertical-nav__link-text">
+                          Home Improvement
+                        </span>
+                      </a>
+                    </li>
+                    <li class="pf-vertical-sub-nav__item" aria-level="2">
+                      <a href="#" class="pf-vertical-sub-nav__link">
+                        <span class="pf-c-vertical-nav__link-text">
+                          Lawn and Garden
+                        </span>
+                      </a>
+                    </li>
+                    <li class="pf-vertical-sub-nav__item" aria-level="2">
+                      <a href="#" class="pf-vertical-sub-nav__link">
+                        <span class="pf-c-vertical-nav__link-text">
+                          Green Living
+                        </span>
+                      </a>
+                    </li>
+                    <li class="pf-vertical-sub-nav__item" aria-level="2">
+                      <a href="#" aria-disabled="true" class="pf-vertical-sub-nav__link pf-is-disabled">Stain Removal</a>
+                    </li>
+                  </ul>
+                </section>
+              </li>
+
+              <li class="pf-c-vertical-nav__item">
+                <a href="#" aria-disabled="true" class="pf-c-vertical-nav__link pf-is-disabled">
+                  <span class="pf-c-vertical-nav__link-icon">
+                    <i class="fas fa-home"></i></span>
+                  <span class="pf-c-vertical-nav__link-text">
+                    Culture
+                  </span>
+                </a>
+              </li>
+
+              <li class="pf-c-vertical-nav__item">
+                <a href="#" class="pf-c-vertical-nav__link">
+                  <span class="pf-c-vertical-nav__link-icon"><i class="fas fa-home"></i></span>
+                  <span class="pf-c-vertical-nav__link-text">Entertainment</span>
+                </a>
+              </li>
+
+            </ul>
+          </nav>
+      </div>
+
+      <div class="col">
+        <ul>
+            <li>focus programatically shifts to first menu item in submenu</li>
+            <li>role="list" for outermost ul</li>
+            <li>role="link" for each nav item's anchor</li>
+            <li>dynamic aria-expanded on each menu anchor</li>
+            <li>dynamic aria-current for menu anchors</li>
+            <li>properly relays expanded/collapsed state in VoiceOver links menu</li>
+            <li>submenu links are dynamically listed properly in VO links menu once they are expanded</li>
+            <li>Technology link launches an alertdialog</li>
+            <li>Entertainment link launches a status</li>
+            <li>Adjusting aria-live didn't have a noticable impact on UX for VO in any of the toast notifications</li>
+            <li>role="status" doesn't seem to report the status info the same way alertdialog does</li>
           </ul>
-        </section>
-      </li>
-
-      <li class="pf-c-vertical-nav__item">
-        <a
-          href="#"
-          aria-expanded="false"
-          aria-controls="navbarSubmenu4"
-          class="pf-c-vertical-nav__link"
-          id="navbarDropdownMenuLink4">
-          <span class="pf-c-vertical-nav__link-icon">
-            <i class="fas fa-home"></i>
-          </span>
-          <span class="pf-c-vertical-nav__link-text">Home and Garden</span>
-        </a>
-
-        <!-- HTML NOTES
-        The following menu has a variation, where aria-level is used to identify list level
-        Aside from the additional aria attribute, the JS updates should be the same for this section -->
-        <section class="pf-vertical-sub-nav" aria-labelledby="navbarDropdownMenuLink4" id="navbarSubmenu4" aria-hidden="true">
-          <h2 class="pf-vertical-sub-nav__title">Home and Garden</h2>
-          <ul class="pf-vertical-sub-nav__content">
-            <li class="pf-vertical-sub-nav__item" aria-level="2">
-              <a href="#" class="pf-vertical-sub-nav__link">
-                <span class="pf-c-vertical-nav__link-text">
-                  Home Improvement
-                </span>
-              </a>
-            </li>
-            <li class="pf-vertical-sub-nav__item" aria-level="2">
-              <a href="#" class="pf-vertical-sub-nav__link">
-                <span class="pf-c-vertical-nav__link-text">
-                  Lawn and Garden
-                </span>
-              </a>
-            </li>
-            <li class="pf-vertical-sub-nav__item" aria-level="2">
-              <a href="#" class="pf-vertical-sub-nav__link">
-                <span class="pf-c-vertical-nav__link-text">
-                  Green Living
-                </span>
-              </a>
-            </li>
-            <li class="pf-vertical-sub-nav__item" aria-level="2">
-              <a href="#" aria-disabled="true" class="pf-vertical-sub-nav__link pf-is-disabled">Stain Removal</a>
-            </li>
-          </ul>
-        </section>
-      </li>
-
-      <li class="pf-c-vertical-nav__item">
-        <a href="#" aria-disabled="true" class="pf-c-vertical-nav__link pf-is-disabled">
-          <span class="pf-c-vertical-nav__link-icon">
-            <i class="fas fa-home"></i></span>
-          <span class="pf-c-vertical-nav__link-text">
-            Culture
-          </span>
-        </a>
-      </li>
-
-      <li class="pf-c-vertical-nav__item">
-        <a href="#" class="pf-c-vertical-nav__link">
-          <span class="pf-c-vertical-nav__link-icon"><i class="fas fa-home"></i></span>
-          <span class="pf-c-vertical-nav__link-text">Entertainment</span>
-        </a>
-      </li>
-
-    </ul>
-  </nav>
-  <main>
-    <ul>
-      <li>role="list" for outermost ul</li>
-      <li>role="link" for each nav item's anchor</li>
-      <li>dynamic aria-expanded on each menu anchor</li>
-      <li>dynamic aria-current for menu anchors</li>
-      <li>properly relays expanded/collapsed state in VoiceOver links menu</li>
-      <li>submenu links are dynamically listed properly in VO links menu once they are expanded</li>
-      <li>Technology link launches an alertdialog</li>
-      <li>Entertainment link launches a status</li>
-      <li>Adjusting aria-live didn't have a noticable impact on UX for VO in any of the toast notifications</li>
-      <li>role="status" doesn't seem to report the status info the same way alertdialog does</li>
-    </ul>
-
-    <!-- Variation 2, identify alertdialog with sr-only text after the icon -->
-    <!-- adding aria-describedby causes VO to read the message twice -->
-    <div
-      id="technology-warning"
-      aria-hidden="true"
-      class="pf-c-toast pf-is-warning">
-      <div role="alert" aria-live="assertive">
-        <div class="pf-c-toast__icon">
-          <i class="fas fa-home"></i>
-          <span id="technology-warning-title" class="sr-only">Warning message:</span>
-        </div>
-        <div id="technology-warning-message" class="pf-c-toast__message">
-          Technology is scary, and may include topics that are confusing.
-        </div>
       </div>
-      <div class="pf-c-toast__action">
-        <a href="#">Exclude Confusing Topics</a>
-        <button data-dismiss aria-label="Dismiss Notification">
-          <i class="fas fa-times"></i>
-        </button>
-      </div>
-    </div>
+  </div>
 
-    <!-- Variation 2, identify status with sr-only text after the icon -->
-    <!-- adding aria-describedby causes VO to read the message twice -->
-    <div
-      id="entertainment-info"
-      aria-hidden="true"
-      class="pf-c-toast pf-is-success">
-      <div role="alert" aria-live="polite">
-        <div class="pf-c-toast__icon">
-          <i class="fas fa-home"></i>
-          <span id="entertainment-success-title" class="sr-only">Success message:</span>
-        </div>
-        <div id="entertainment-success-message" class="pf-c-toast__message">
-          Entertainment comes in many forms like music, art, and poetry.
-        </div>
-      </div>
-      <div class="pf-c-toast__action">
-        <button data-dismiss aria-label="Dismiss Notification">
-          <i class="fas fa-times"></i>
-        </button>
-      </div>
-    </div>
 
-  </main>
+  <main></main>
   <script src="https://code.jquery.com/jquery-3.3.1.js" integrity="sha256-2Kok7MbOyxpgUVvAk/HJ2jigOSYS2auK4Pfzbm7uH60=" crossorigin="anonymous"></script>
   <script src="js/navbar-list.js"></script>
 </body>

--- a/navbar-menubar.html
+++ b/navbar-menubar.html
@@ -10,187 +10,194 @@
 <body>
 
   <header role="banner">
-    <h1>Menubar demo</h1>
+    <h1>Menubar with submenus demo</h1>
   </header>
 
-  <nav class="pf-c-vertical-nav">
-    <ul class="pf-c-vertical-nav__content" role="menubar">
+  <div class="flexContainer flexSpaceAround">
+      <div class="col">
+        <nav class="pf-c-vertical-nav">
+          <ul class="pf-c-vertical-nav__content" role="menubar">
 
-      <li class="pf-c-vertical-nav__item">
-        <a
-          href="#"
-          class="pf-c-vertical-nav__link">
-          <span class="pf-c-vertical-nav__link-icon"><i class="fas fa-home"></i></span>
-          <span class="pf-c-vertical-nav__link-text">Home</span>
-        </a>
-      </li>
-
-      <li class="pf-c-vertical-nav__item">
-        <a
-          href="#"
-          class="pf-c-vertical-nav__link">
-          <span class="pf-c-vertical-nav__link-icon"><i class="fas fa-home"></i></span>
-          <span class="pf-c-vertical-nav__link-text">Technology</span>
-        </a>
-      </li>
-
-      <li class="pf-c-vertical-nav__item">
-        <a
-          href="#"
-          aria-expanded="false"
-          aria-controls="navbarSubmenu3"
-          aria-current="false"
-          class="pf-c-vertical-nav__link"
-          role="menuitem"
-          id="navbarDropdownMenuLink3"> <!-- pf-is-active class is added to links that are open -->
-          <span class="pf-c-vertical-nav__link-icon">
-            <i class="fas fa-home"></i>
-          </span>
-          <span class="pf-c-vertical-nav__link-text">
-            Science
-          </span>
-        </a>
-
-        <section
-          class="pf-vertical-sub-nav"
-          aria-hidden="true"
-          aria-labelledby="navbarDropdownMenuLink3"
-          id="navbarSubmenu3"> <!-- pf-is-open class is added to sections that are open -->
-          <h2 class="pf-vertical-sub-nav__title">Science</h2>
-          <ul class="pf-vertical-sub-nav__content">
-            <li class="pf-vertical-sub-nav__item">
+            <li class="pf-c-vertical-nav__item">
               <a
                 href="#"
-                class="pf-vertical-sub-nav__link">
-                <span class="pf-c-vertical-nav__link-text">
-                    Environmental Science
-                </span>
+                class="pf-c-vertical-nav__link">
+                <span class="pf-c-vertical-nav__link-icon"><i class="fas fa-home"></i></span>
+                <span class="pf-c-vertical-nav__link-text">Home</span>
               </a>
             </li>
-            <li class="pf-vertical-sub-nav__item">
+
+            <li class="pf-c-vertical-nav__item">
               <a
                 href="#"
+                class="pf-c-vertical-nav__link">
+                <span class="pf-c-vertical-nav__link-icon"><i class="fas fa-home"></i></span>
+                <span class="pf-c-vertical-nav__link-text">Technology</span>
+              </a>
+            </li>
+
+            <li class="pf-c-vertical-nav__item">
+              <a
+                href="#"
+                aria-expanded="false"
+                aria-controls="navbarSubmenu3"
                 aria-current="false"
-                class="pf-vertical-sub-nav__link">
+                class="pf-c-vertical-nav__link"
+                role="menuitem"
+                id="navbarDropdownMenuLink3"> <!-- pf-is-active class is added to links that are open -->
+                <span class="pf-c-vertical-nav__link-icon">
+                  <i class="fas fa-home"></i>
+                </span>
                 <span class="pf-c-vertical-nav__link-text">
-                  Physical Science
+                  Science
                 </span>
               </a>
+
+              <section
+                class="pf-vertical-sub-nav"
+                hidden
+                aria-labelledby="navbarDropdownMenuLink3"
+                id="navbarSubmenu3"> <!-- pf-is-open class is added to sections that are open -->
+                <h2 class="pf-vertical-sub-nav__title">Science</h2>
+                <ul class="pf-vertical-sub-nav__content">
+                  <li class="pf-vertical-sub-nav__item">
+                    <a
+                      href="#"
+                      class="pf-vertical-sub-nav__link">
+                      <span class="pf-c-vertical-nav__link-text">
+                          Environmental Science
+                      </span>
+                    </a>
+                  </li>
+                  <li class="pf-vertical-sub-nav__item">
+                    <a
+                      href="#"
+                      aria-current="false"
+                      class="pf-vertical-sub-nav__link">
+                      <span class="pf-c-vertical-nav__link-text">
+                        Physical Science
+                      </span>
+                    </a>
+                  </li>
+                  <li class="pf-vertical-sub-nav__item">
+                    <a
+                      href="#"
+                      class="pf-vertical-sub-nav__link">
+                      <span class="pf-c-vertical-nav__link-text">
+                        Life Science
+                      </span>
+                    </a>
+                  </li>
+                  <li class="pf-vertical-sub-nav__item">
+                    <a
+                      href="#"
+                      aria-disabled="true"
+                      class="pf-vertical-sub-nav__link pf-is-disabled">
+                      Engineering
+                    </a>
+                  </li>
+                </ul>
+              </section>
             </li>
-            <li class="pf-vertical-sub-nav__item">
+
+            <li class="pf-c-vertical-nav__item">
               <a
                 href="#"
-                class="pf-vertical-sub-nav__link">
-                <span class="pf-c-vertical-nav__link-text">
-                  Life Science
+                role="link"
+                aria-expanded="false"
+                aria-controls="navbarSubmenu4"
+                class="pf-c-vertical-nav__link"
+                id="navbarDropdownMenuLink4">
+                <span class="pf-c-vertical-nav__link-icon">
+                  <i class="fas fa-home"></i>
                 </span>
+                <span class="pf-c-vertical-nav__link-text">Home and Garden</span>
               </a>
+
+              <section
+                class="pf-vertical-sub-nav"
+                aria-labelledby="navbarDropdownMenuLink4"
+                hidden
+                id="navbarSubmenu4">
+                <h2 class="pf-vertical-sub-nav__title">Home and Garden</h2>
+                <ul class="pf-vertical-sub-nav__content">
+                  <li class="pf-vertical-sub-nav__item" aria-level="2">
+                    <a
+                      href="#"
+                      class="pf-vertical-sub-nav__link">
+                      <span class="pf-c-vertical-nav__link-text">
+                        Home Improvement
+                      </span>
+                    </a>
+                  </li>
+                  <li class="pf-vertical-sub-nav__item" aria-level="2">
+                    <a
+                      href="#"
+                      class="pf-vertical-sub-nav__link">
+                      <span class="pf-c-vertical-nav__link-text">
+                        Lawn and Garden
+                      </span>
+                    </a>
+                  </li>
+                  <li class="pf-vertical-sub-nav__item" aria-level="2">
+                    <a
+                      href="#"
+                      class="pf-vertical-sub-nav__link">
+                      <span class="pf-c-vertical-nav__link-text">
+                        Green Living
+                      </span>
+                    </a>
+                  </li>
+                  <li class="pf-vertical-sub-nav__item" aria-level="2">
+                    <a
+                      href="#"
+                      aria-disabled="true"
+                      class="pf-vertical-sub-nav__link pf-is-disabled">
+                      Stain Removal
+                    </a>
+                  </li>
+                </ul>
+              </section>
             </li>
-            <li class="pf-vertical-sub-nav__item">
+
+            <li class="pf-c-vertical-nav__item">
               <a
                 href="#"
                 aria-disabled="true"
-                class="pf-vertical-sub-nav__link pf-is-disabled">
-                Engineering
+                class="pf-c-vertical-nav__link pf-is-disabled">
+                <span class="pf-c-vertical-nav__link-icon">
+                  <i class="fas fa-home"></i></span>
+                <span class="pf-c-vertical-nav__link-text">
+                  Culture
+                </span>
               </a>
             </li>
+
+            <li class="pf-c-vertical-nav__item">
+              <a
+                href="#"
+                class="pf-c-vertical-nav__link">
+                <span class="pf-c-vertical-nav__link-icon"><i class="fas fa-home"></i></span>
+                <span class="pf-c-vertical-nav__link-text">Entertainment</span>
+              </a>
+            </li>
+
           </ul>
-        </section>
-      </li>
+        </nav>
+      </div><!-- .col -->
 
-      <li class="pf-c-vertical-nav__item">
-        <a
-          href="#"
-          role="link"
-          aria-expanded="false"
-          aria-controls="navbarSubmenu4"
-          class="pf-c-vertical-nav__link"
-          id="navbarDropdownMenuLink4">
-          <span class="pf-c-vertical-nav__link-icon">
-            <i class="fas fa-home"></i>
-          </span>
-          <span class="pf-c-vertical-nav__link-text">Home and Garden</span>
-        </a>
+      <div class="col">
+        <ul>
+          <li>features role="menubar" on the outermost ul</li>
+          <li>features role="menuitem" on each menu anchor</li>
+          <li>features dynamic aria-expanded on each menu anchor</li>
+          <li>features dynamic aria-current on each menu anchor</li>
+          <li>properly relays expanded/collapsed state in VoiceOver Form Controls menu</li>
+        </ul>
+      </div><!-- .col -->
+    </div>
 
-        <section
-          class="pf-vertical-sub-nav"
-          aria-labelledby="navbarDropdownMenuLink4"
-          aria-hidden="true"
-          id="navbarSubmenu4">
-          <h2 class="pf-vertical-sub-nav__title">Home and Garden</h2>
-          <ul class="pf-vertical-sub-nav__content">
-            <li class="pf-vertical-sub-nav__item" aria-level="2">
-              <a
-                href="#"
-                class="pf-vertical-sub-nav__link">
-                <span class="pf-c-vertical-nav__link-text">
-                  Home Improvement
-                </span>
-              </a>
-            </li>
-            <li class="pf-vertical-sub-nav__item" aria-level="2">
-              <a
-                href="#"
-                class="pf-vertical-sub-nav__link">
-                <span class="pf-c-vertical-nav__link-text">
-                  Lawn and Garden
-                </span>
-              </a>
-            </li>
-            <li class="pf-vertical-sub-nav__item" aria-level="2">
-              <a
-                href="#"
-                class="pf-vertical-sub-nav__link">
-                <span class="pf-c-vertical-nav__link-text">
-                  Green Living
-                </span>
-              </a>
-            </li>
-            <li class="pf-vertical-sub-nav__item" aria-level="2">
-              <a
-                href="#"
-                aria-disabled="true"
-                class="pf-vertical-sub-nav__link pf-is-disabled">
-                Stain Removal
-              </a>
-            </li>
-          </ul>
-        </section>
-      </li>
-
-      <li class="pf-c-vertical-nav__item">
-        <a
-          href="#"
-          aria-disabled="true"
-          class="pf-c-vertical-nav__link pf-is-disabled">
-          <span class="pf-c-vertical-nav__link-icon">
-            <i class="fas fa-home"></i></span>
-          <span class="pf-c-vertical-nav__link-text">
-            Culture
-          </span>
-        </a>
-      </li>
-
-      <li class="pf-c-vertical-nav__item">
-        <a
-          href="#"
-          class="pf-c-vertical-nav__link">
-          <span class="pf-c-vertical-nav__link-icon"><i class="fas fa-home"></i></span>
-          <span class="pf-c-vertical-nav__link-text">Entertainment</span>
-        </a>
-      </li>
-
-    </ul>
-  </nav>
-  <main>
-    <ul>
-      <li>features role="menubar" on the outermost ul</li>
-      <li>features role="menuitem" on each menu anchor</li>
-      <li>features dynamic aria-expanded on each menu anchor</li>
-      <li>features dynamic aria-current on each menu anchor</li>
-      <li>properly relays expanded/collapsed state in VoiceOver Form Controls menu</li>
-    </ul>
-  </main>
+  <main></main>
   <script src="https://code.jquery.com/jquery-3.3.1.js" integrity="sha256-2Kok7MbOyxpgUVvAk/HJ2jigOSYS2auK4Pfzbm7uH60=" crossorigin="anonymous"></script>
   <script src="js/navbar-menubar.js"></script>
 </body>

--- a/sass/base.scss
+++ b/sass/base.scss
@@ -18,25 +18,18 @@ body {
   text-rendering: optimizeLegibility;
 }
 
-.nav-list-example {
-  // Keep visual interface and screen reader in lock-step
-  [aria-hidden="true"]:not(.svg-inline--fa) {
-    display: none;
-  }
-
-  .flexContainer {
-    display: flex;
-  }
-  .flexSpaceAround {
-      justify-content: space-around;
-  }
-  .col {
-      width: 44%;
-      border: 1px solid #777777;
-      border-radius: 8px;
-      background: white;
-      padding: 20px;
-  }
+.flexContainer {
+  display: flex;
+}
+.flexSpaceAround {
+    justify-content: space-around;
+}
+.col {
+    width: 44%;
+    border: 1px solid #777777;
+    border-radius: 8px;
+    background: white;
+    padding: 20px;
 }
 
 // VERTICAL NAV
@@ -97,15 +90,13 @@ body {
 }
 
 // Sub menu
-//
 .pf-vertical-sub-nav {
   display: none;
 
-  // &.pf-is-open {
-  //   display: block;
-  // }
-  // rather, base display on aria-hidden
-  &:not([aria-hidden="true"]) {
+  // base submenu display on combination of presentation class and aria attribute being set correctly
+  // this prevents scenario where menu displays for sighted users, but not for screen reader
+  // (a.k.a "The contract")
+  &.pf-is-open:not([hidden]) {
     display: block;
   }
 }

--- a/single-notification.html
+++ b/single-notification.html
@@ -2,68 +2,65 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Navigation Example</title>
+  <title>Single Notification Container Example</title>
   <link rel="stylesheet" href="node_modules/normalize.css/normalize.css">
   <link rel="stylesheet" href="css/base.css">
   <script defer src="https://use.fontawesome.com/releases/v5.0.6/js/all.js"></script>
 </head>
-<body class="nav-list-example">
+<body>
 
   <header role="banner">
-    <h1>Navigation list launching submenus and notifications demo</h1>
+    <h1>Single notification container, with multiple types of notifications</h1>
   </header>
 
-  <nav class="pf-c-vertical-nav">
-    <ul class="pf-c-vertical-nav__content" role="list">
-      <li class="pf-c-vertical-nav__item">
+  <div class="flexContainer flexSpaceAround">
+    <div class="col">
+      <nav class="pf-c-vertical-nav">
+          <ul class="pf-c-vertical-nav__content" role="list">
+            <li class="pf-c-vertical-nav__item">
 
-        <a href="#" class="pf-c-vertical-nav__link">
-          <span class="pf-c-vertical-nav__link-icon"><i class="fas fa-home"></i></span>
-          <span class="pf-c-vertical-nav__link-text">Alert</span>
-        </a>
-      </li>
+              <a href="#" class="pf-c-vertical-nav__link">
+                <span class="pf-c-vertical-nav__link-icon"><i class="fas fa-home"></i></span>
+                <span class="pf-c-vertical-nav__link-text">Alert</span>
+              </a>
+            </li>
 
-      <li class="pf-c-vertical-nav__item">
-        <a href="#" class="pf-c-vertical-nav__link">
-          <span class="pf-c-vertical-nav__link-icon"><i class="fas fa-home"></i></span>
-          <span class="pf-c-vertical-nav__link-text">Alert Dialog</span>
-        </a>
-      </li>
+            <li class="pf-c-vertical-nav__item">
+              <a href="#" class="pf-c-vertical-nav__link">
+                <span class="pf-c-vertical-nav__link-icon"><i class="fas fa-home"></i></span>
+                <span class="pf-c-vertical-nav__link-text">Alert Dialog</span>
+              </a>
+            </li>
 
-      <li class="pf-c-vertical-nav__item">
-        <a href="#" class="pf-c-vertical-nav__link">
-          <span class="pf-c-vertical-nav__link-icon"><i class="fas fa-home"></i></span>
-          <span class="pf-c-vertical-nav__link-text">Status</span>
-        </a>
-      </li>
+            <li class="pf-c-vertical-nav__item">
+                <a href="#" class="pf-c-vertical-nav__link">
+                  <span class="pf-c-vertical-nav__link-icon"><i class="fas fa-home"></i></span>
+                  <span class="pf-c-vertical-nav__link-text">Dialog</span>
+                </a>
+              </li>
 
-    </ul>
-  </nav>
-  <main>
+            <li class="pf-c-vertical-nav__item">
+              <a href="#" class="pf-c-vertical-nav__link">
+                <span class="pf-c-vertical-nav__link-icon"><i class="fas fa-home"></i></span>
+                <span class="pf-c-vertical-nav__link-text">Status</span>
+              </a>
+            </li>
 
-    <!-- Variation 2, identify alertdialog with sr-only text after the icon -->
-    <div
-      id="notification-element"
-      aria-hidden="true"
-      aria-labelledby="notification-element-title"
-      aria-describedby="notification-element-message"
-      class="pf-c-toast pf-is-warning">
-      <div class="pf-c-toast__icon">
-        <i class="fas fa-home"></i>
-        <span id="notification-element-title" class="sr-only">ALERT:</span>
-      </div>
-      <div id="notification-element-message" class="pf-c-toast__message">
-        Technology is scary, are you sure you want to proceed?
-      </div>
-      <div class="pf-c-toast__action">
-        <a href="#">Continue</a>
-        <button data-dismiss aria-label="Dismiss Notification" style="display:inline-block;">
-          <i class="fas fa-times"></i>
-        </button>
-      </div>
+          </ul>
+        </nav>
+    </div><!-- .col -->
+
+    <div class="col">
+      <ul>
+        <li>uses js to manage focus with event.preventDefault()</li>
+        <li>using href="#" or href="#navbarSubmenuID" exhibit same behavior</li>
+        <li>focus index remains on the submenu toggle upon expanding dropdown, unless we programatically shift focus to something else</li>
+      </ul>
     </div>
+  </div>
 
-  </main>
+
+  <main></main>
   <script src="https://code.jquery.com/jquery-3.3.1.js" integrity="sha256-2Kok7MbOyxpgUVvAk/HJ2jigOSYS2auK4Pfzbm7uH60=" crossorigin="anonymous"></script>
   <script src="js/single-notification.js"></script>
 </body>

--- a/submenu-flow-js.html
+++ b/submenu-flow-js.html
@@ -7,10 +7,10 @@
   <link rel="stylesheet" href="css/base.css">
   <script defer src="https://use.fontawesome.com/releases/v5.0.6/js/all.js"></script>
 </head>
-<body class="nav-list-example">
+<body>
 
   <header role="banner">
-    <h1>Managing focus with named JavaScript</h1>
+    <h1>Focus doesn't shift when opening submenu</h1>
   </header>
 
   <div class="flexContainer flexSpaceAround">
@@ -46,7 +46,7 @@
 
             <section
               class="pf-vertical-sub-nav"
-              aria-hidden="true"
+              hidden
               aria-labelledby="navbarDropdownMenuLink01"
               id="navbarSubmenu01">
               <h2 class="pf-vertical-sub-nav__title">Science</h2>
@@ -90,7 +90,7 @@
               class="pf-vertical-sub-nav"
               aria-labelledby="navbarDropdownMenuLink02"
               id="navbarSubmenu02"
-              aria-hidden="true">
+              hidden>
               <h2 class="pf-vertical-sub-nav__title">Home and Garden</h2>
               <ul class="pf-vertical-sub-nav__content">
                 <li class="pf-vertical-sub-nav__item" aria-level="2">
@@ -142,9 +142,9 @@
 
     <div class="col">
       <ul>
-        <li>uses js to manage focus with event.preventDefault()</li>
+        <li>uses JavaScript to prevent default browser actions from happening upon menu item selection</li>
         <li>using href="#" or href="#navbarSubmenuID" exhibit same behavior</li>
-        <li>focus index remains on the submenu toggle upon expanding dropdown, unless we programatically shift focus to something else</li>
+        <li>focus index remains on the submenu toggle upon expanding dropdown, unless we programatically shift focus to something else. This seems to provide the best experience so far, as it's predictable where the other examples were not.</li>
       </ul>
     </div><!-- .col -->
   </div>

--- a/submenu-flow.html
+++ b/submenu-flow.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="css/base.css">
   <script defer src="https://use.fontawesome.com/releases/v5.0.6/js/all.js"></script>
 </head>
-<body class="nav-list-example">
+<body>
 
   <header role="banner">
     <h1>Managing focus with named anchors</h1>
@@ -46,7 +46,7 @@
 
             <section
               class="pf-vertical-sub-nav"
-              aria-hidden="true"
+              hidden
               aria-label="Science"
               id="navbarSubmenu01">
               <h2 class="pf-vertical-sub-nav__title">Science</h2>
@@ -90,7 +90,7 @@
               class="pf-vertical-sub-nav"
               aria-labelledby="navbarDropdownMenuLink02"
               id="navbarSubmenu02"
-              aria-hidden="true">
+              hidden>
               <h2 class="pf-vertical-sub-nav__title">Home and Garden</h2>
               <ul class="pf-vertical-sub-nav__content">
                 <li class="pf-vertical-sub-nav__item" aria-level="2">
@@ -142,9 +142,10 @@
 
     <div class="col">
       <ul>
-        <li>menu items with dropdown specify named anchors for submenus containers</li>
-        <li>default browser behavior can be observed, we do not use event.preventDefault() in this example</li>
-        <li>focus index is shifted upon selecting a menu item with dropdown</li>
+        <li>menu items with dropdown specify named anchors for submenus containers, for example href="navbarSubmenu01"</li>
+        <li>default browser behavior is observed, we do not use event.preventDefault() in this example</li>
+        <li>focus index is shifted upon selecting a menu item with a dropdown, but becuase the target element is hidden, focus is sort of lost until user makes a subsequent key press like right arrow or tab</li>
+        <li>Science submenu is labeled directly with aria-label="Science", and with this users are able to place focus on the submenu as a region. This is in contrast to the "Home and Garden" submenu, which uses aria-labelledby="navbarDropdownMenuLink02". The latter doesn't allow for focusing directly on the region, but a subsequent keypress places focus on the submenu header, which could be desireable.</li>
       </ul>
     </div><!-- .col -->
   </div>

--- a/visible-submenu-flow.html
+++ b/visible-submenu-flow.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="css/base.css">
   <script defer src="https://use.fontawesome.com/releases/v5.0.6/js/all.js"></script>
 </head>
-<body class="nav-list-example">
+<body>
 
   <header role="banner">
     <h1>Managing focus with named anchors to visible submenu container</h1>
@@ -48,7 +48,7 @@
               class="pf-vertical-sub-nav"
               aria-label="Science"
               id="navbarSubmenu01">
-              <div aria-hidden="true">
+              <div hidden>
                 <h2 class="pf-vertical-sub-nav__title">Science</h2>
                 <ul class="pf-vertical-sub-nav__content">
                   <li class="pf-vertical-sub-nav__item">
@@ -91,7 +91,7 @@
               class="pf-vertical-sub-nav"
               aria-labelledby="navbarDropdownMenuLink02"
               id="navbarSubmenu02">
-              <div aria-hidden="true">
+              <div hidden>
                 <h2 class="pf-vertical-sub-nav__title">Home and Garden</h2>
                 <ul class="pf-vertical-sub-nav__content">
                   <li class="pf-vertical-sub-nav__item" aria-level="2">
@@ -146,8 +146,9 @@
       <ul>
         <li>submenu container is always visible in the DOM, contents of submenu is what's being hidden/shown</li>
         <li>menu items with dropdown specify named anchors for submenus containers</li>
-        <li>default browser behavior can be observed, we do not use event.preventDefault() in this example</li>
+        <li>default browser behavior is observed, we do not use event.preventDefault() in this example</li>
         <li>focus index is shifted upon selecting a menu item with dropdown</li>
+        <li>Science submenu is labeled directly with aria-label="Science", and with this users are able to place focus on the submenu region by simply selecting that menu item again or pressing the right arrow key. This is in contrast to the "Home and Garden" submenu, which uses aria-labelledby="navbarDropdownMenuLink02". The latter doesn't allow for focusing directly on the region which could be problematic.</li>
       </ul>
     </div><!-- .col -->
   </div>


### PR DESCRIPTION
This PR includes quite a bit of refactoring, and attempts to only introduce enhancements to the existing screen reader experience.

The main changes here are

- completely removing the notification containers from the html files, and instead injecting these using js
- swapping out aria-hidden for hidden on submenu containers, and notifications
- add more demos
- two column layout for demo pages
- updates to in-page notes

Ongoing work toward https://github.com/patternfly/patternfly-next/issues/172

Submenu visibility no longer relies on aria-hidden
Submenu visibility now relies on both pf-is-open and not hidden
use standard hidden attribute over aria-hidden for submenus
notification demos now add/remove entire notification from DOM via JS
new criteria for hasSubmenu and getSubmenu
dump aria-controls when target element is adjacent sibling
flesh out some notes in demo pages
give demo pages a better, simple layout
hide with hidden over aria-hidden where possible