### PR TITLE
Update toast test page to clarify examples used

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -115,8 +115,9 @@ body {
   border: 1px solid black;
   margin: 1rem; }
   .pf-c-toast__icon {
-    min-width: 4rem;
+    width: 4rem;
     padding: 1rem;
+    float: left;
     color: #fff;
     background-color: lightgray; }
   .pf-c-toast.pf-is-success {

--- a/toast.html
+++ b/toast.html
@@ -9,121 +9,160 @@
 </head>
 
 <body>
-<aside aria-label="notifications">
-  <!-- Variation 1, identify alert with aria label on alert parent -->
-  <article class="pf-c-toast pf-is-danger">
-    <div role="alert" aria-live="assertive" aria-label="Error alert">
+
+  <header role="banner">
+    <h1>Toast notifications</h1>
+  </header>
+  <aside aria-label="notifications">
+    <!-- Variation 1, identify alert with aria label on alert parent -->
+    <article class="pf-c-toast pf-is-danger" id="varOne">
+      <div role="alert" aria-live="assertive" aria-label="Error alert 1">
+        <div class="pf-c-toast__icon" aria-hidden="true">
+          <i class="fas fa-home"></i>
+        </div>
+        <div class="pf-c-toast__message">
+          (Variation 1) Something bad has happened and you should know about it.
+        </div>
+      </div>
+      <div class="pf-c-toast__action">
+        <a href="#0">Fix It</a>
+
+        <button role="button" aria-label="Dismiss Message" aria-controls="varOne">
+          <i class="fas fa-times"></i>
+        </button>
+      </div>
+    </article>
+
+    <!-- Variation 2, identify alert with sr-only text after the icon -->
+    <!-- the alternative text for the icon seems to work best with this variation -->
+    <article class="pf-c-toast pf-is-warning">
       <div class="pf-c-toast__icon" aria-hidden="true">
         <i class="fas fa-home"></i>
       </div>
-      <div class="pf-c-toast__message">
-        Something bad has happened and you should know about it.
+      <div class="pf-c-toast__message" role="alert" aria-live="assertive">
+        <span class="sr-only">Warning alert 2:</span>
+        (Variation 2) Something bad could happen, but you have the ability to stop it.
       </div>
-    </div>
-    <div class="pf-c-toast__action">
-      <a href="#0">Fix It</a>
+      <div class="pf-c-toast__action">
+        <a href="#0">Stop It</a>
 
-      <button aria-label="Dismiss Message">
-        <i class="fas fa-times"></i>
-      </button>
-    </div>
-  </article>
-
-  <!-- Variation 2, identify alert with sr-only text after the icon -->
-  <!-- the alternative text for the icon seems to work best with this variation -->
-  <article class="pf-c-toast pf-is-warning">
-    <div class="pf-c-toast__icon" aria-hidden="true">
-      <i class="fas fa-home"></i>
-    </div>
-    <div class="pf-c-toast__message" role="alert" aria-live="assertive">
-      <span class="sr-only">Warning alert:</span>
-      Something bad could happen, but you have the ability to stop it.
-    </div>
-    <div class="pf-c-toast__action">
-      <a href="#0">Stop It</a>
-
-      <button aria-label="Dismiss Message">
-        <i class="fas fa-times"></i>
-      </button>
-    </div>
-  </article>
-
-
-  <!-- Variation 3, identify alert with title text on icon -->
-  <article class="pf-c-toast pf-is-success">
-    <div role="alert" aria-live="polite">
-      <div class="pf-c-toast__icon">
-        <i class="fas fa-home" title="Success message"></i>
+        <button aria-label="Dismiss Message">
+          <i class="fas fa-times"></i>
+        </button>
       </div>
-      <div class="pf-c-toast__message">
-        Something great just happened. You should celebrate.
-      </div>
-    </div>
-    <div class="pf-c-toast__action">
-      <a href="#0">Celebrate</a>
+    </article>
 
-      <div class="pf-c-dropdown pf-to-right">
-        <div class="pf-c-dropdown__trigger">
-          <button role="button" class="pf-c-btn" type="button" id="dropdownMenuButton" data-toggle="pf-c-dropdown" aria-haspopup="true" aria-expanded="false" aria-label="More Actions">
-            <i class="fas fa-ellipsis-v"></i>
-          </button>
+
+    <!-- Variation 3, identify alert with title text on icon -->
+    <article class="pf-c-toast pf-is-success">
+      <div role="alert" aria-live="polite">
+        <div class="pf-c-toast__icon">
+          <i class="fas fa-home" title="Success message 3"></i>
         </div>
-
-        <div class="pf-c-dropdown__menu" aria-labelledby="dropdownMenuButton">
-          <a class="pf-c-dropdown__link" href="#">Action</a>
-          <a class="pf-c-dropdown__link" href="#">Another action</a>
-          <a class="pf-c-dropdown__link" href="#">Something else here</a>
+        <div class="pf-c-toast__message">
+          (Variation 3) Something great just happened. You should celebrate.
         </div>
       </div>
+      <div class="pf-c-toast__action">
+        <a href="#0">Celebrate</a>
 
-    </div>
-  </article>
+        <div class="pf-c-dropdown pf-to-right">
+          <div class="pf-c-dropdown__trigger">
+            <button role="button" class="pf-c-btn" type="button" id="dropdownMenuButton" data-toggle="pf-c-dropdown" aria-haspopup="true" aria-expanded="false" aria-label="More Actions">
+              <i class="fas fa-ellipsis-v"></i>
+            </button>
+          </div>
 
-  <!-- Variation 4 icon svg with aria-label -->
-  <article class="pf-c-toast pf-is-danger">
-    <div role="alert" aria-live="assertive">
-      <div class="pf-c-toast__icon">
-        <svg aria-label="Error message" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-          <circle cx="10" cy="10" r="10" />
-        </svg>
+          <div class="pf-c-dropdown__menu" aria-labelledby="dropdownMenuButton">
+            <a class="pf-c-dropdown__link" href="#">Action</a>
+            <a class="pf-c-dropdown__link" href="#">Another action</a>
+            <a class="pf-c-dropdown__link" href="#">Something else here</a>
+          </div>
+        </div>
+
       </div>
-      <div class="pf-c-toast__message">
-        Something bad has happened and you should know about it.
+    </article>
+
+    <!-- Variation 4 icon svg with aria-label -->
+    <article class="pf-c-toast pf-is-danger">
+      <div role="alert" aria-live="assertive">
+        <div class="pf-c-toast__icon">
+          <svg aria-label="Error message 4" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" style="width: 2em;">
+            <circle cx="10" cy="10" r="10" />
+          </svg>
+        </div>
+        <div class="pf-c-toast__message">
+          (Variation 4) Something bad has happened and you should know about it.
+        </div>
+      </div>
+      <div class="pf-c-toast__action">
+        <a href="#0">Fix It</a>
+        <button aria-label="Dismiss Message">
+          <i class="fas fa-times"></i>
+        </button>
+      </div>
+    </article>
+
+    <!-- Variation 5 using dialog instead of article -->
+    <!-- should role="dialog" be included -->
+    <div
+      role="dialog"
+      class="pf-c-toast pf-is-warning"
+      aria-labelledby="dialog1Title"
+      aria-describedby="dialog1Message">
+      <div class="pf-c-toast__icon" aria-hidden="true">
+        <i class="fas fa-home"></i>
+      </div>
+      <div class="pf-c-toast__message" role="alert" aria-live="assertive">
+        <span id="dialog1Title" class="sr-only">Warning alert 5:</span>
+        <span id="dialog1Message">
+          (Variation 5) Something bad could happen, but you have the ability to stop it.
+        </span>
+      </div>
+      <div class="pf-c-toast__action">
+        <a href="#0">Stop It</a>
+
+        <button aria-label="Dismiss Message">
+          <i class="fas fa-times"></i>
+        </button>
       </div>
     </div>
-    <div class="pf-c-toast__action">
-      <a href="#0">Fix It</a>
-      <button aria-label="Dismiss Message">
-        <i class="fas fa-times"></i>
-      </button>
-    </div>
-  </article>
+    <script src="js/kebab.js"></script>
+  </aside>
+  <p>Toast notification examples are implemented using different markup.</p>
+  <ul>
+      <li>Variation 1:
+        <ul>
+          <li>Parent element is an Article</li>
+          <li>Alert type is provided in the form of aria-label on the div with role="alert" that contains the icon and text message</li>
+          <li>Dismiss button includes aria-controls pointing to the parent Article element</li>
+        </ul>
+      </li>
+      <li>Variation 2:
+        <ul>
+          <li>Parent element is an Article</li>
+          <li>Alert type is included as screen-reader-only text in a span</li>
+        </ul>
+      </li>
+      <li>Variation 3:
+        <ul>
+          <li>Parent element is an Article</li>
+          <li>Alert type is included as title text for the fontawesome icon, and this text gets converted to a title element when the icon is converted to an svg element</li>
+        </ul>
+      </li>
+      <li>Variation 4:
+        <ul>
+          <li>Parent element is an Article</li>
+          <li>Alert type is included as aria-label for an svg element</li>
+        </ul>
+      </li>
+      <li>Variation 5:
+        <ul>
+          <li>Parent element is a div with role="dialog"</li>
+          <li>Alert type is included as screen-reader-only text in a span (like variation 2)</li>
+        </ul>
+      </li>
+    </ul>
 
-  <!-- Variation 5 using dialog instead of article -->
-  <!-- should role="dialog" be included -->
-  <div
-    role="dialog"
-    class="pf-c-toast pf-is-warning"
-    aria-labelledby="dialog1Title"
-    aria-describedby="dialog1Message">
-    <div class="pf-c-toast__icon" aria-hidden="true">
-      <i class="fas fa-home"></i>
-    </div>
-    <div class="pf-c-toast__message" role="alert" aria-live="assertive">
-      <span id="dialog1Title" class="sr-only">Warning alert:</span>
-      <span id="dialog1Message">
-        Something bad could happen, but you have the ability to stop it.
-      </span>
-    </div>
-    <div class="pf-c-toast__action">
-      <a href="#0">Stop It</a>
-
-      <button aria-label="Dismiss Message">
-        <i class="fas fa-times"></i>
-      </button>
-    </div>
-  </div>
-  <script src="js/kebab.js"></script>
-</aside>
 </body>
 </html>


### PR DESCRIPTION
- Included numbers for the type text and message text to help differentiate between the notifications when announced
- Included descriptions of different html used for each variation
- Set width for one of the svg icons
- Updated css so that icons were floating