### PR TITLE
[patternfly-next-172] demo updates

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -115,9 +115,8 @@ body {
   border: 1px solid black;
   margin: 1rem; }
   .pf-c-toast__icon {
-    width: 4rem;
+    min-width: 4rem;
     padding: 1rem;
-    float: left;
     color: #fff;
     background-color: lightgray; }
   .pf-c-toast.pf-is-success {

--- a/index.html
+++ b/index.html
@@ -10,29 +10,30 @@
 
     <div class="flexContainer flexSpaceAround">
       <nav class="col">
-        <h2>Vertical Navigation Examples</h2>
+        <h2>Vertical Navigation Structure Examples</h2>
         <ul>
           <li><a href="nav.html">Navbar Latest and greatest</a></li>
           <li><a href="navbar-list.html">Navbar as a list</a></li>
           <li><a href="navbar-menubar.html">Navbar as a menu</a></li>
           <li><a href="navbar-aria.html">Navbar ARIA</a></li>
         </ul>
-        <h2>Submenu tab/focus flow examples</h2>
+        <h2>Keyboard Navigation Flow</h2>
         <ul>
-          <li><a href="focus-flow.html">Focus flow with named anchors</a></li>
-          <li><a href="submenu-flow.html">Tab flow for standard submenu</a></li>
-          <li><a href="visible-submenu-flow.html">Tab flow for submenu with visible container</a></li>
-          <li><a href="submenu-flow-js.html">Tab flow for submenu (focus remains on toggle)</a></li>
+          <li><a href="submenu-flow.html">Tab flow with named anchors (hidden submenu container)</a></li>
+          <li><a href="visible-submenu-flow.html">Tab flow with named anchors (visible submenu container)</a></li>
+          <li><a href="submenu-flow-js.html">Tab flow with JS (focus remains on toggle)</a></li>
+          <li><a href="submenu-focus-shift.html">Tab flow with JS (focus programatically shifts to submenu)</a></li>
+          <li><a href="focus-flow.html">Basic in-page navigation</a></li>
         </ul>
         <h2>Toast Notification examples</h2>
         <ul>
           <li><a href="single-notification.html">Dynamically Injected Notifications</a></li>
           <li><a href="toast.html">Toast</a></li>
         </ul>
-        <h2>Dialog Examples</h2>
+        <!-- <h2>Dialog Examples</h2>
         <ul>
           <li><a href="dialog.html">Dialogs Example</a></li>
-        </ul>
+        </ul> -->
         <h2>Kebab examples</h2>
         <ul>
           <li><a href="kebab.html">Kebab</a></li>

--- a/js/submenu-focus-shift.js
+++ b/js/submenu-focus-shift.js
@@ -1,0 +1,150 @@
+(function ($) {
+  'use strict';
+
+  let menuItemDepth = function ($menuItem) {
+    return $menuItem.parents('li').length;
+  },
+
+  hasSubmenu = function ($menuItem) {
+    return !!$menuItem.find('+ section').length;
+  },
+
+  subMenuIsVisible = function ($subMenu) {
+    return !!$subMenu.is(':visible');
+  },
+
+  hideEl = function ($element) {
+    $element.attr('hidden', 'hidden');
+  },
+
+  showEl = function ($element) {
+    $element.removeAttr('hidden');
+  },
+
+  openMenu = function ($menuItem, $subMenu) {
+    $menuItem.attr('aria-expanded', true);
+    $subMenu.addClass('pf-is-open');
+    showEl($subMenu);
+  },
+
+  closeMenu = function ($menuItem, $subMenu) {
+    $menuItem.attr('aria-expanded', false);
+    $subMenu.removeClass('pf-is-open');
+    hideEl($subMenu);
+  },
+
+  getMenuItemLnk = function (item) {
+    return $(item).find('> a');
+  },
+
+  focusFirstMenuItem = function ($element) {
+    $element.find('a:first').trigger('focus');
+  },
+
+  getSubMenu = function ($listItem) {
+    return $listItem.find('> a + section');
+  },
+
+  closeOpenMenus = function ($menuItems) {
+    $.each($menuItems, function (idx, item) {
+      if (getMenuItemLnk(item).attr('aria-expanded') === 'true') {
+        let $subMenu = getSubMenu($(item));
+        closeMenu(getMenuItemLnk(item), $subMenu);
+      }
+    });
+  },
+
+  removeActiveClasses = function ($menuItems) {
+    $.each($menuItems, function (idx, item) {
+      if (getMenuItemLnk(item).is('.pf-is-active')) {
+        getMenuItemLnk(item).removeClass('pf-is-active');
+      }
+    });
+  },
+
+  removeAriaCurrent = function ($menuItems) {
+    $.each($menuItems, function (idx, item) {
+      if (getMenuItemLnk(item).attr('aria-current') === 'true') {
+        getMenuItemLnk(item).attr('aria-current', false);
+      }
+    });
+  },
+
+  popNotification = function ($element) {
+    showEl($element);
+  },
+
+  bindMenuEvents = function ($listItem, idx, $menuItems) {
+    let $menuItem = $listItem.find('> a');
+
+    $menuItem.on('focusout focusin', function (event) {
+      event.preventDefault();
+
+      let $subMenu = getSubMenu($listItem);
+
+      switch (event.type) {
+
+        case 'focusin': {
+
+          $menuItem.on('click', function (event) {
+            event.preventDefault();
+            event.stopImmediatePropagation();
+
+            if (hasSubmenu($menuItem)) {
+              if ($subMenu.attr('hidden') === 'hidden') {
+
+                // first close any subMenus that are already open
+                closeOpenMenus($menuItems);
+
+                openMenu($menuItem, $subMenu);
+                focusFirstMenuItem($subMenu);
+              } else {
+                closeMenu($menuItem, $subMenu);
+              }
+            }
+
+            // only set as pf-is-active/aria-current if menu item isn't disabled and isn't only a gateway to submenu
+            if (!hasSubmenu($menuItem) && $menuItem.is(':not([aria-disabled])')) {
+              removeActiveClasses($menuItems);
+              removeAriaCurrent($menuItems);
+              $menuItem.addClass('pf-is-active').attr('aria-current', true);
+
+              if (menuItemDepth($menuItem) === 1) {
+                closeOpenMenus($menuItems);
+              }
+            }
+
+          });
+
+          break;
+        }
+
+        case 'focusout': {
+          $menuItem.off('click');
+          break;
+        }
+
+        default: {
+          // console.log('unsupported event type');
+        }
+      }
+      return false;
+    });
+  };
+
+  document.addEventListener("DOMContentLoaded", function(event) {
+    let $menuItems = $('.pf-c-vertical-nav__item, .pf-vertical-sub-nav__item');
+
+    $.each($menuItems, function (idx, element) {
+      let $listItem = $(element);
+      bindMenuEvents($listItem, idx, $menuItems);
+      getMenuItemLnk(element).attr('role', 'link');
+    });
+
+    $('.pf-c-toast').on('click', '[data-dismiss]', function () {
+      hideEl($(this).parents('.pf-c-toast'));
+      $(this).parents('.pf-c-toast').blur();
+    });
+  });
+
+})(jQuery);

--- a/navbar-list.html
+++ b/navbar-list.html
@@ -179,7 +179,6 @@
 
       <div class="col">
         <ul>
-          <li>focus programatically shifts to first menu item in submenu</li>
           <li>role="list" for outermost ul</li>
           <li>role="link" for each nav item's anchor</li>
           <li>dynamic aria-expanded on each menu anchor</li>

--- a/submenu-flow-js.html
+++ b/submenu-flow-js.html
@@ -145,7 +145,7 @@
         <li>by using aria-label="Label Name" on the submenu container, instead of aria-labelledby="IDREF", the submenu shows up in the VoiceOver landmarks rotor menu as "Label Name Region"</li>
         <li>uses JavaScript to prevent default browser actions from happening upon menu item selection</li>
         <li>using href="#" or href="#navbarSubmenuID" exhibit same behavior</li>
-        <li>focus index remains on the submenu toggle upon expanding dropdown, unless we programatically shift focus to something else. This seems to provide the best experience so far, as it's predictable where the other examples were not.</li>
+        <li>this seems to provide the best experience so far, as it's predictable where the other examples were not.</li>
       </ul>
     </div><!-- .col -->
   </div>

--- a/submenu-focus-shift.html
+++ b/submenu-focus-shift.html
@@ -10,7 +10,7 @@
 <body>
 
   <header role="banner">
-    <h1>Managing focus with named anchors to hidden submenu container</h1>
+    <h1>Focus automatically shifted when opening submenu</h1>
   </header>
 
   <div class="flexContainer flexSpaceAround">
@@ -33,7 +33,7 @@
 
           <li class="pf-c-vertical-nav__item">
             <a
-              href="#navbarSubmenu01"
+              href="#"
               aria-expanded="false"
               aria-current="false"
               class="pf-c-vertical-nav__link"
@@ -76,7 +76,7 @@
 
           <li class="pf-c-vertical-nav__item">
             <a
-              href="#navbarSubmenu02"
+              href="#"
               aria-expanded="false"
               class="pf-c-vertical-nav__link"
               id="navbarDropdownMenuLink02">
@@ -142,14 +142,13 @@
 
     <div class="col">
       <ul>
-        <li>menu items with dropdowns specify named anchors for submenus containers, for example href="navbarSubmenu01"</li>
-        <li>default browser behavior is observed, we do not use event.preventDefault() in this example</li>
-        <li>focus index is shifted upon selecting a menu item with a dropdown, but becuase the target element is hidden, focus is sort of lost until user makes a subsequent key press like right arrow or tab</li>
-        <li>in this prototype submenus are labeled using aria-label="Label Name", and because of this the submenu is exposed as a region, allowing users to find and place focus on the submenu as a whole, and not just the menu items within</li>
+        <li>focus programatically shifts to first menu item in submenu</li>
+        <li>uses JavaScript to prevent default browser actions from happening on menu item selection</li>
+        <li>using href="#" or href="#navbarSubmenuID" exhibit same behavior</li>
       </ul>
     </div><!-- .col -->
   </div>
   <script src="https://code.jquery.com/jquery-3.3.1.js" integrity="sha256-2Kok7MbOyxpgUVvAk/HJ2jigOSYS2auK4Pfzbm7uH60=" crossorigin="anonymous"></script>
-  <script src="js/submenu-flow.js"></script>
+  <script src="js/submenu-focus-shift.js"></script>
 </body>
 </html>

--- a/visible-submenu-flow.html
+++ b/visible-submenu-flow.html
@@ -6,6 +6,11 @@
   <link rel="stylesheet" href="node_modules/normalize.css/normalize.css">
   <link rel="stylesheet" href="css/base.css">
   <script defer src="https://use.fontawesome.com/releases/v5.0.6/js/all.js"></script>
+  <style>
+    .pf-vertical-sub-nav {
+      display: block;
+    }
+  </style>
 </head>
 <body>
 
@@ -89,7 +94,7 @@
 
             <section
               class="pf-vertical-sub-nav"
-              aria-labelledby="navbarDropdownMenuLink02"
+              aria-label="Home and Garden"
               id="navbarSubmenu02">
               <div hidden>
                 <h2 class="pf-vertical-sub-nav__title">Home and Garden</h2>
@@ -148,7 +153,7 @@
         <li>menu items with dropdown specify named anchors for submenus containers</li>
         <li>default browser behavior is observed, we do not use event.preventDefault() in this example</li>
         <li>focus index is shifted upon selecting a menu item with dropdown</li>
-        <li>Science submenu is labeled directly with aria-label="Science", and with this users are able to place focus on the submenu region by simply selecting that menu item again or pressing the right arrow key. This is in contrast to the "Home and Garden" submenu, which uses aria-labelledby="navbarDropdownMenuLink02". The latter doesn't allow for focusing directly on the region which could be problematic.</li>
+        <li>submenus labeled with aria-labelledby="IDREF" don't allow for focusing directly on the region by pressing right arrow key after selecting submenu toggle, which is problematic but I believe this could be due to a shortcoming in the implementation</li>
       </ul>
     </div><!-- .col -->
   </div>


### PR DESCRIPTION
This PR better organizes the demo app and adds a new variation that's dedicated for navigation where focus is programatically shifted to the first menu item in a submenu after selecting the source menu item.

Ongoing work toward https://github.com/patternfly/patternfly-next/issues/172