### PR TITLE
[patternfly-next-172] demo for showcasing aria-label on various elements

### DIFF
--- a/aria-label.html
+++ b/aria-label.html
@@ -25,14 +25,22 @@
 
         <div class="example">
           <h2>Buttons with aria-label</h2>
-          <button type="button" aria-label="Aria Label Text">Button with aria-label text</button>
-          <button type="button">Button without aria-label text</button>
-          <button type="submit" aria-label="Aria Label Text">Submit Button with aria-label text</button>
+          <!-- case: btn with aria-label and text node -->
+          <button type="button" aria-label="Aria Label Text">Button with aria-label text</button><br>
+          <!-- case: btn with only text node -->
+          <button type="button">Button without aria-label text</button><br>
+          <!-- case: submit btn with aria-label and text node -->
+          <button type="submit" aria-label="Aria Label Text">Submit Button with aria-label text</button><br>
+          <!-- case: btn with aria-label and nested text node -->
           <button type="button" aria-label="Aria Label Text">
-            <span>
-              Nested Span in
-            </span>
+            <span>Nested Span in</span>
             Button with aria-label
+          </button><br>
+          <!-- case: btn with only aria-label, without text node -->
+          <button type="button" aria-label="Aria Label Text"></button><br>
+          <!-- case: btn with aria-label and nested element with aria-label -->
+          <button type="button" aria-label="Aria Label Text">
+            <i class="fas fa-home" aria-label="Nested Aria Label Text"></i>
           </button>
         </div>
 
@@ -127,6 +135,7 @@
           <li>Buttons with aria-label do not read aloud the button text nodes, but instead read the aria-label along with the button's role.</li>
           <li>Headings with aria-label read the heading level then the aria-label text in place of the heading text.</li>
           <li>Dialogs with aria-label first read the element that's initially given focus, then the aria-label text, and mention it's a group, other text elements in the dialog are not read aloud. If the dialog doesn't have an aria-label, the dialog's full contents are ready in source order</li>
+          <li>Buttons with aria-label and no text node read the aria-label followed by the elements role</li>
         </ul>
         <h4>Elements who's text is supplimented by aria-label</h4>
         <ul>

--- a/aria-label.html
+++ b/aria-label.html
@@ -1,0 +1,112 @@
+<!doctype html>
+<html lang="en-US">
+<head>
+  <meta charset="utf-8">
+  <title>Focus Flow Example</title>
+  <link rel="stylesheet" href="node_modules/normalize.css/normalize.css">
+  <link rel="stylesheet" href="css/base.css">
+  <script defer src="https://use.fontawesome.com/releases/v5.0.6/js/all.js"></script>
+  <style>
+    .example {
+      border: 2px dashed grey;
+    }
+  </style>
+</head>
+<body>
+  <main>
+
+    <header role="banner">
+      <h1>Aria Label Examples</h1>
+      <p>This demo illustrates the impact that adding an aria-label attribute has on various html elements.</p>
+    </header>
+
+    <div class="flexContainer flexSpaceAround">
+      <div class="col">
+
+        <div class="example">
+          <h2>Buttons with aria-label</h2>
+          <button type="button">Button without aria-label text</button>
+          <button type="button" aria-label="Aria Label Text">Button with aria-label text</button>
+          <button type="submit" aria-label="Aria Label Text">Submit Button with aria-label text</button>
+          <button type="button" aria-label="Aria Label Text">
+            <span>
+              Nested Span text
+            </span>
+            Button text
+          </button>
+        </div>
+
+        <div class="example">
+          <h2>Paragraph with aria-label</h2>
+          <p aria-label="Aria Label Text">Paragraph with aria-label text</p>
+        </div>
+
+        <div class="example">
+          <h2>Heading with aria-label</h2>
+          <h3 aria-label="Aria Label Text">Heading with aria-label text</h3>
+          <h3>Heading without aria-label Text</h3>
+        </div>
+
+        <div class="example">
+          <h2>Span with aria-label</h2>
+          <span aria-label="Aria Label Text">Span with aria-label text</span>
+          <span>Span without aria-label text</span>
+        </div>
+
+        <div class="example">
+          <h2>Article with aria-label</h2>
+          <article aria-label="Aria Label Text">Article with aria-label text</article>
+          <article>Article without aria-label text</article>
+        </div>
+
+        <div class="example">
+          <h2>Aside with aria-label</h2>
+          <aside aria-label="Aria Label Text">Aside with aria-label text</aside>
+          <aside>Aside without aria-label text</aside>
+        </div>
+
+        <div class="example">
+          <h2>Section with aria-label</h2>
+          <section aria-label="Aria Label Text">Section with aria-label text</section>
+          <section>Section without aria-label text</section>
+        </div>
+
+        <div class="example">
+          <h2>Nav with aria-label</h2>
+          <nav aria-label="Aria Label Text">Nav with aria-label text</nav>
+          <nav>Nav without aria-label text</nav>
+        </div>
+
+        <div class="example">
+          <h2>Header with aria-label</h2>
+          <header aria-label="Aria Label Text">Header with aria-label text</header>
+          <header>Header without aria-label text</header>
+        </div>
+
+        <div class="example">
+          <h2>Footer with aria-label</h2>
+          <footer aria-label="Aria Label Text">Footer with aria-label text</footer>
+          <footer>Footer without aria-label text</footer>
+        </div>
+
+      </div><!-- .col -->
+
+      <div class="col">
+        <ul>
+          <li>button's with aria-label do not read aloud the button text nodes, but instead read the aria-label along with the button's role</li>
+          <li>paragraph's with aria-label first read the aria-label, then mention it's a group, and after a subsequent keypress read aloud the paragraph text</li>
+          <li>heading's with aria-label read the heading level then the aria-label text in place of the heading text</li>
+          <li>span's with aria-label first read the aria-label text and then announce the span as a group, subsequent keypress reads aloud the normal span text</li>
+          <li>article's with aria-label first read the aria-label text and then announces it as an article, subsequent keypress reads aloud the normal article text</li>
+          <li>aside's with aria-label first read the aria-label text and then announces it as a complimentary, subsequent keypress reads aloud the normal aside text</li>
+          <li>section's with aria-label first read the aria-label text and then announces it as a region, subsequent keypress reads aloud the normal section text</li>
+          <li>nav's with aria-label first read the aria-label text and then announces it as a navigation, subsequent keypress reads aloud the normal section text</li>
+          <li>header's with aria-label first read the aria-label text and then announces it as a group, subsequent keypress reads aloud the normal header text</li>
+          <li>footer's with aria-label first read the aria-label text and then announces it as a group, subsequent keypress reads aloud the normal footer text</li>
+        </ul>
+      </div><!-- .col -->
+    </div>
+
+  </main>
+</body>
+</html>

--- a/aria-label.html
+++ b/aria-label.html
@@ -25,88 +25,125 @@
 
         <div class="example">
           <h2>Buttons with aria-label</h2>
-          <button type="button">Button without aria-label text</button>
           <button type="button" aria-label="Aria Label Text">Button with aria-label text</button>
+          <button type="button">Button without aria-label text</button>
           <button type="submit" aria-label="Aria Label Text">Submit Button with aria-label text</button>
           <button type="button" aria-label="Aria Label Text">
             <span>
-              Nested Span text
+              Nested Span in
             </span>
-            Button text
+            Button with aria-label
           </button>
         </div>
 
         <div class="example">
-          <h2>Paragraph with aria-label</h2>
-          <p aria-label="Aria Label Text">Paragraph with aria-label text</p>
-        </div>
-
-        <div class="example">
-          <h2>Heading with aria-label</h2>
+          <h2>Headings with aria-label</h2>
           <h3 aria-label="Aria Label Text">Heading with aria-label text</h3>
           <h3>Heading without aria-label Text</h3>
         </div>
 
         <div class="example">
-          <h2>Span with aria-label</h2>
+          <h2>Paragraphs with aria-label</h2>
+          <p aria-label="Aria Label Text">Paragraph with aria-label text</p>
+          <p>Paragraph without aria-label</p>
+        </div>
+
+        <div class="example">
+          <h2>Spans with aria-label</h2>
           <span aria-label="Aria Label Text">Span with aria-label text</span>
           <span>Span without aria-label text</span>
         </div>
 
         <div class="example">
-          <h2>Article with aria-label</h2>
+          <h2>Articles with aria-label</h2>
           <article aria-label="Aria Label Text">Article with aria-label text</article>
           <article>Article without aria-label text</article>
         </div>
 
         <div class="example">
-          <h2>Aside with aria-label</h2>
+          <h2>Dialogs with aria-label</h2>
+          <button id="aria-label-dialog-btn" type="button">Launch dialog with aria-label</button>
+          <button id="standard-dialog-btn" type="button">Launch dialog without aria-label</button>
+
+          <dialog id="aria-label-dialog" aria-label="Aria Label Text">
+            Dialog with aria-label text
+            <a href="#">Dialog Action</a>
+            <button type="button" data-dismiss>Dismiss</button>
+          </dialog>
+
+          <dialog id="standard-dialog">
+            Dialog without aria-label text
+            <a href="#">Dialog Action</a>
+            <button type="button" data-dismiss>Dismiss</button>
+          </dialog>
+        </div>
+
+        <div class="example">
+          <h2>Asides with aria-label</h2>
           <aside aria-label="Aria Label Text">Aside with aria-label text</aside>
           <aside>Aside without aria-label text</aside>
         </div>
 
         <div class="example">
-          <h2>Section with aria-label</h2>
+          <h2>Sections with aria-label</h2>
           <section aria-label="Aria Label Text">Section with aria-label text</section>
           <section>Section without aria-label text</section>
         </div>
 
         <div class="example">
-          <h2>Nav with aria-label</h2>
+          <h2>Navs with aria-label</h2>
           <nav aria-label="Aria Label Text">Nav with aria-label text</nav>
           <nav>Nav without aria-label text</nav>
         </div>
 
         <div class="example">
-          <h2>Header with aria-label</h2>
+          <h2>Headers with aria-label</h2>
           <header aria-label="Aria Label Text">Header with aria-label text</header>
           <header>Header without aria-label text</header>
         </div>
 
         <div class="example">
-          <h2>Footer with aria-label</h2>
+          <h2>Footers with aria-label</h2>
           <footer aria-label="Aria Label Text">Footer with aria-label text</footer>
           <footer>Footer without aria-label text</footer>
+        </div>
+
+        <div class="example">
+          <h2>Unordered Lists with aria-label</h2>
+          <ul aria-label="Aria Label Text">
+            <li>Unordered list with aria-label</li>
+          </ul>
+          <ul>
+            <li>Unordered list without aria-label</li>
+          </ul>
         </div>
 
       </div><!-- .col -->
 
       <div class="col">
+        <h2>VoiceOver Results</h2>
+        <h4>Elements who's text is replaced by aria-label</h4>
         <ul>
-          <li>button's with aria-label do not read aloud the button text nodes, but instead read the aria-label along with the button's role</li>
-          <li>paragraph's with aria-label first read the aria-label, then mention it's a group, and after a subsequent keypress read aloud the paragraph text</li>
-          <li>heading's with aria-label read the heading level then the aria-label text in place of the heading text</li>
-          <li>span's with aria-label first read the aria-label text and then announce the span as a group, subsequent keypress reads aloud the normal span text</li>
-          <li>article's with aria-label first read the aria-label text and then announces it as an article, subsequent keypress reads aloud the normal article text</li>
-          <li>aside's with aria-label first read the aria-label text and then announces it as a complimentary, subsequent keypress reads aloud the normal aside text</li>
-          <li>section's with aria-label first read the aria-label text and then announces it as a region, subsequent keypress reads aloud the normal section text</li>
-          <li>nav's with aria-label first read the aria-label text and then announces it as a navigation, subsequent keypress reads aloud the normal section text</li>
-          <li>header's with aria-label first read the aria-label text and then announces it as a group, subsequent keypress reads aloud the normal header text</li>
-          <li>footer's with aria-label first read the aria-label text and then announces it as a group, subsequent keypress reads aloud the normal footer text</li>
+          <li>Buttons with aria-label do not read aloud the button text nodes, but instead read the aria-label along with the button's role.</li>
+          <li>Headings with aria-label read the heading level then the aria-label text in place of the heading text.</li>
+          <li>Dialogs with aria-label first read the element that's initially given focus, then the aria-label text, and mention it's a group, other text elements in the dialog are not read aloud. If the dialog doesn't have an aria-label, the dialog's full contents are ready in source order</li>
+        </ul>
+        <h4>Elements who's text is supplimented by aria-label</h4>
+        <ul>
+          <li>Paragraphs with aria-label first read the aria-label, then mention it's a group, and after a subsequent keypress read aloud the paragraph text.</li>
+          <li>Spans with aria-label first read the aria-label text and then announce the span as a group, subsequent keypress reads aloud the normal span text.</li>
+          <li>Articles with aria-label first read the aria-label text and then announces it as an article, subsequent keypress reads aloud the normal article text.</li>
+          <li>Asides with aria-label first read the aria-label text and then announces it as a complimentary, subsequent keypress reads aloud the normal aside text.</li>
+          <li>Sections with aria-label first read the aria-label text and then announces it as a region, subsequent keypress reads aloud the normal section text.</li>
+          <li>Navs with aria-label first read the aria-label text and then announces it as a navigation, subsequent keypress reads aloud the normal section text.</li>
+          <li>Headers with aria-label first read the aria-label text and then announces it as a group, subsequent keypress reads aloud the normal header text.</li>
+          <li>Footers with aria-label first read the aria-label text and then announces it as a group, subsequent keypress reads aloud the normal footer text.</li>
+          <li>Unordered lists with aria-label first read that it's a list, then read the aria-label text, and then announce the number of items in the list, subsequent keypress reads aloud the individual li text.</li>
         </ul>
       </div><!-- .col -->
     </div>
 
   </main>
+  <script src="js/aria-label.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -34,10 +34,14 @@
         <ul>
           <li><a href="dialog.html">Dialogs Example</a></li>
         </ul> -->
-        <h2>Kebab examples</h2>
+        <h2>Kebab Examples</h2>
         <ul>
           <li><a href="kebab.html">Kebab</a></li>
           <li><a href="kebab2.html">Kebab 2</a></li>
+        </ul>
+        <h2>Aria Attribute Examples</h2>
+        <ul>
+          <li><a href="aria-label.html">aria-label</a></li>
         </ul>
       </nav><!-- .col -->
 

--- a/js/aria-label.js
+++ b/js/aria-label.js
@@ -1,0 +1,34 @@
+(function () {
+  'use strict';
+
+  let setupDialog01 = function () {
+    document.getElementById('aria-label-dialog-btn').addEventListener('click', function () {
+      document.getElementById('aria-label-dialog').setAttribute('open', 'open');
+      document.querySelectorAll('#aria-label-dialog > button')[0].focus();
+    });
+  },
+
+  setupDialog02 = function () {
+    document.getElementById('standard-dialog-btn').addEventListener('click', function () {
+      document.getElementById('standard-dialog').setAttribute('open', 'open');
+      document.querySelectorAll('#standard-dialog > button')[0].focus();
+    });
+  },
+
+  setupDismissBtns = function () {
+    document.querySelectorAll('[data-dismiss]').forEach(function (el) {
+      el.addEventListener('click', function (event) {
+        el.blur();
+        this.parentElement.removeAttribute('open');
+        document.getElementById(this.parentElement.id + '-btn').focus();
+      });
+    });
+  };
+
+  document.addEventListener("DOMContentLoaded", function(event) {
+    setupDialog01();
+    setupDialog02();
+    setupDismissBtns();
+  });
+})();
+


### PR DESCRIPTION
This PR introduces a new type of demo, a JavaScript-less page with many of the main types of html elements, each having a version with and without an `aria-label` attribute attached to it.

In most cases, the aria-label text is announced before and in addition to whatever text nodes were already present in the element.

For buttons and headings, the aria-label text was read in place of the actual text nodes that existed within the element.

Ongoing work toward https://github.com/patternfly/patternfly-next/issues/172